### PR TITLE
Fix fileio functions

### DIFF
--- a/watchme/tests/test_utils.py
+++ b/watchme/tests/test_utils.py
@@ -111,15 +111,6 @@ class TestUtils(unittest.TestCase):
         result = which('echo')
         self.assertEqual(result, '/bin/echo')
 
-    def test_userhome(self):
-        print('Testing utils.get_user')
-        print('Testing utils.get_userhome')
-        from watchme.utils import get_userhome
-        from watchme.utils import get_user
-        user = get_user()
-        userhome = get_userhome()
-        self.assertEqual('/home/%s' % user, userhome)
-
     def test_files(self):
         print('Testing utils.generate_temporary_files')
         from watchme.utils import generate_temporary_file

--- a/watchme/utils/fileio.py
+++ b/watchme/utils/fileio.py
@@ -12,14 +12,10 @@ the watched to check for changes at some frequency, and update the files.
 
 '''
 
-import configparser
 import errno
 import os
-import pwd
-import re
 import tempfile
 import json
-import io
 import socket
 import shutil
 import sys

--- a/watchme/utils/fileio.py
+++ b/watchme/utils/fileio.py
@@ -23,6 +23,7 @@ import io
 import socket
 import shutil
 import sys
+import getpass
 
 from watchme.logger import bot
 
@@ -31,11 +32,11 @@ from watchme.logger import bot
 def get_userhome():
     '''get the user home based on the effective uid
     '''
-    return pwd.getpwuid(os.getuid())[5]
+    return os.path.expanduser("~")
 
 def get_user():
     '''return the active user'''
-    return os.path.basename(get_userhome())
+    return getpass.getuser()
 
 def get_host():
     '''return the hostname'''


### PR DESCRIPTION
* Closes #19 
* The rationale behind 4b23cc7 is that we can't assume that the home dir is going to be `/home/<uname>`. For example, I'm on OSX and so my home dir is` /Users/cbaker`, hence the test that I dropped in 4b23cc7 was failing.