### PR TITLE
Adding user agent header, regex for URL watcher tasks

### DIFF
--- a/.github/AUTHORS.md
+++ b/.github/AUTHORS.md
@@ -1,0 +1,7 @@
+# Maintainers
+
+ - [@vsoch](https://www.github.com/vsoch)
+
+# Contributors
+
+ - [@SCHKN](https://www.github.com/SCHKN)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Critical items to know are:
  - changed behaviour
 
 ## [master](https://github.com/vsoch/watchme/tree/master)
+ - Adding option for regular expression for URL wachers, user agent header (0.0.16)
  - requests is missing from install dependencies (0.0.15)
  - small bug fixes (0.0.14)
  - added headers, params, and json args for post and get urls. (0.0.13)

--- a/docs/_docs/examples/index.md
+++ b/docs/_docs/examples/index.md
@@ -5,8 +5,9 @@ permalink: /examples/index.html
 order: 1
 ---
 
-We will have more examples and details, but for now, here are the example watcher
-repos:
+## Repository Examples
+
+Here you can find example watcher repos:
 
  - [system](https://github.com/vsoch/watchme-system) for system, sensors, users, and networking monitoring using psutils tasks.
  - [air-quality](https://github.com/vsoch/watchme-air-quality) for watching a metric across a few cities.
@@ -17,3 +18,29 @@ For either of the above, you can easily install and activate the watcher to run 
 your machine! See [here](https://vsoch.github.io/watchme/getting-started/#how-do-i-get-a-watcher).
 For specific details about creating the watchers in question, see the README markdowns
 in the repositories.
+
+## Configuration Examples
+
+The following example configurations are contributed by users over time. If you
+have an example to contribute, please [open an issue](https://www.github.com/{{ site.repo }}/issues)
+to share it.
+
+### URL Watchers
+
+The following are examples for [URL watchers](https://vsoch.github.io/watchme/watchers/urls/).
+In the following example, the user is using the `get_url_selection` task to extract
+a number (note the regular expression) from the text resulting from selecting the
+class `.local-temp`. For this version of WatchMe the User-Agent header was not
+automatically added, so he added it here as a `header_*` parameter.
+
+```
+[task-temperature]
+url = https://www.accuweather.com/en/lu/luxembourg/228714/weather-forecast/228714
+selection = .local-temp
+get_text = true
+func = get_url_selection
+active = true
+type = urls
+regex = [0-9]+
+header_user-agent = Mozilla/5.0
+```

--- a/docs/_docs/watcher-tasks/urls.md
+++ b/docs/_docs/watcher-tasks/urls.md
@@ -38,6 +38,16 @@ A urls task has the following parameters shared across functions.
 | url  | Yes     |undefined|url@https://www.reddit.com/r/hpc| validated starts with http |
 | func | No    |get_task |func@download_task| must be defined in tasks.py |
 
+
+### Task Headers
+
+For some tasks, you can add one or more headers to the request by specifying `header_<name>`.
+For example, to add the header "Token" I could do `header_Token=123456`.
+By default, each task has the User-Agent header added, as it typically helps. 
+If you want to disable this, add the header_User-Agent to be empty, or change
+it to something else.
+
+
 #### Lists of URL Parameters
 
 For the "Get" and "Get with selection" tasks, you might want to include url parameters. For example,
@@ -68,7 +78,6 @@ or to skip the third page call (page=3) for the name parameter, just leave it em
 ```bash
 url_param_name@V,V,,V,V,V,V
 ```
-
 
 ## Tasks Available
 
@@ -115,7 +124,6 @@ The following custom parameters can be added:
 
 If you specify "save_as" to be json, you will get a results.json unless you specify another
 file name. 
-
 
 
 ### 2. Post to a URL Task

--- a/docs/_docs/watcher-tasks/urls.md
+++ b/docs/_docs/watcher-tasks/urls.md
@@ -39,7 +39,7 @@ A urls task has the following parameters shared across functions.
 | func | No    |get_task |func@download_task| must be defined in tasks.py |
 
 
-### Task Headers
+#### Task Headers
 
 For some tasks, you can add one or more headers to the request by specifying `header_<name>`.
 For example, to add the header "Token" I could do `header_Token=123456`.

--- a/watchme/version.py
+++ b/watchme/version.py
@@ -6,7 +6,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.15"
+__version__ = "0.0.16"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'watchme'


### PR DESCRIPTION
This is a simple PR to add (by default) a user agent header and regular expressions for the URL watcher tasks, along with documentation and example, a good suggestion by @SCHKN. @SCHKN had a great idea to add exporters, and I need to review this more carefully to determine if it can be generalizable enough. For this small PR, I created a shared function to perform the common task of parsing the success response. For exploration of the exporters, @SCHKN added enough new code that I'll attempt to start from him branch to integrate his commits. Thanks for the great help and suggestions y'all!

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>