### PR TITLE
updating watcher task functions to be cleaner, inspired by other PR

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,59 @@
+# WatchMe Code of Conduct v1.0
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+ * Using welcoming and inclusive language
+ * Being respectful of differing viewpoints and experiences
+ * Gracefully accepting constructive criticism
+ * Focusing on what is best for the community
+ * Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+ * The use of sexualized language or imagery and unwelcome sexual attention or advances
+ * Trolling, insulting/derogatory comments, and personal or political attacks
+ * Public or private harassment
+ * Publishing others' private information, such as a physical or electronic address, without explicit permission
+ * Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting @vsoch directly. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. @vsoch is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+## Thanks
+
+This code of conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org/), version 1.4,
+available at http://contributor-covenant.org/version/1/4.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,14 +2,12 @@
 This code is licensed under the MPL 2.0 [LICENSE](LICENSE).
 
 # Contributing
-When contributing to the SIF Python Client, it is important to properly communicate the
+When contributing to the WatchMe Python Client, it is important to properly communicate the
 gist of the contribution. If it is a simple code or editorial fix, simply
 explaining this within the GitHub Pull Request (PR) will suffice. But if this
 is a larger fix or Enhancement, it should be first discussed with the project
-leader or developers.
-
-Please note we have a code of conduct, described below. Please follow it in
-all your interactions with the project members and users.
+leader or developers. Please also note that we have a [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)
+that should be followed for all interactions with the project members and users.
 
 ## Pull Request Process
 
@@ -33,78 +31,7 @@ all your interactions with the project members and users.
    done by the project lead, @vsoch (or approved by her).
 
 
-# Code of Conduct
-
-## Our Pledge
-
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
-
-## Our Standards
-
-Examples of behavior that contributes to creating a positive environment
-include:
-
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
-
-Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
-
-### Our Responsibilities
-
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
-
-## Scope
-
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
-
-## Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project leader (@vsoch). All
-complaints will be reviewed and investigated and will result in a response
-that is deemed necessary and appropriate to the circumstances. The project
-team is obligated to maintain confidentiality with regard to the reporter of
-an incident. Further details of specific enforcement policies may be posted
-separately.
-
-Project maintainers, contributors and users who do not follow or enforce the
-Code of Conduct in good faith may face temporary or permanent repercussions 
-with their involvement in the project as determined by the project's leader(s).
-
-## Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
-
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+When you contribute to the project, you agree to add code under the provided
+licensing terms, and also we ask that you add your name to the [AUTHORS](AUTHORS.md)
+file. Any contribution in the way of documentation, features, or bug fixes is
+greatly appreciated.

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ watchme.egg-info/
 dist
 build
 _site
+.eggs
 __pycache__

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,5 @@ recursive-include watchme *
 recursive-exclude * __pycache__
 recursive-exclude * *.pyc
 recursive-exclude * *.pyo
-recursive-exclude .docs
-recursive-exclude docs
+recursive-exclude .docs *
+recursive-exclude docs *

--- a/docs/_docs/getting-started/index.md
+++ b/docs/_docs/getting-started/index.md
@@ -172,7 +172,7 @@ The configuration commands will vary based on the kind of task you want to add,
 and here is a quick example of adding a task to watch a url (the default task):
 
 ```bash
-$ watchme add watcher task-singularity-release url@https://github.com/sylabs/singularity/releases
+$ watchme add-task watcher task-singularity-release url@https://github.com/sylabs/singularity/releases
 [task-singularity-release]
 url  = https://github.com/sylabs/singularity/releases
 active  = true
@@ -207,7 +207,7 @@ The task is active by default (after you set up its schedule) and you can disabl
 this with --active false:
 
 ```bash
-$ watchme add watcher task-singularity-release url@https://github.com/sylabs/singularity/releases --active false
+$ watchme add-task watcher task-singularity-release url@https://github.com/sylabs/singularity/releases --active false
 ```
 
 The reason we save these parameters in the repo is that if you put it under version
@@ -639,5 +639,4 @@ $ watchme export system task-cpu vanessa-thinkpad-t460s_vanessa.json  --json
 
 ## Licenses
 
-This code is licensed under the Affero GPL, version 3.0 or later [LICENSE](LICENSE).
-The SIF Header format is licesed by [Sylabs](https://github.com/sylabs/sif/blob/master/pkg/sif/sif.go).
+This code is licensed under the Mozilla, version 2.0 or later [LICENSE](LICENSE).

--- a/docs/_docs/install/index.md
+++ b/docs/_docs/install/index.md
@@ -10,7 +10,8 @@ order: 1
 
 The only dependency for watchme is to have [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) 
 and [crontab](https://www.digitalocean.com/community/tutorials/how-to-use-cron-to-automate-tasks-on-a-vps) on your system. Git is used for version control of the pages you are watching, and crontab is
-used for scheduling your watches.
+used for scheduling your watches. If you want to install a custom watcher type, 
+see [installing extras](#installing-extras) below.
 
 ## Install
 
@@ -62,3 +63,26 @@ actions:
 
 
 If you have any questions or issues, please [open an issue]({{ site.repo }}/issues).
+
+## Installing Extras
+
+If you want to install all of watchme's exporters and watchers:
+
+```bash
+$ pip install watchme[all]
+```
+
+To install all watchers only:
+
+```bash
+$ pip install watchme[watchers]
+```
+
+or a specific watcher task group:
+
+```bash
+$ pip install watchme[watcher-urls-dynamic]
+$ pip install watchme[watcher-psutils]
+```
+
+To see all of the choices, see [here](https://github.com/vsoch/watchme/blob/master/setup.py#L109) in the setup file.

--- a/docs/_docs/watcher-tasks/psutils.md
+++ b/docs/_docs/watcher-tasks/psutils.md
@@ -11,7 +11,7 @@ basic python environment. If your python installation doesn't have the `psutil`
 module, install as follows:
 
 ```bash
-pip install watchme[psutils]
+pip install watchme[watcher-psutils]
 ```
 
 Next, create a watcher for your tasks to live under:

--- a/docs/_docs/watcher-tasks/urls.md
+++ b/docs/_docs/watcher-tasks/urls.md
@@ -194,7 +194,7 @@ identified by a class or id) on a page. For this purpose, you can use the functi
 packages to do this:
 
 ```bash
-$ pip install watchme[urls-dynamic]
+$ pip install watchme[watcher-urls-dynamic]
 ```
 
 This task will watch for changes based on a selection from a page. For example, 

--- a/setup.py
+++ b/setup.py
@@ -10,15 +10,15 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
 from setuptools import setup, find_packages
-import codecs
 import os
 
 ################################################################################
 # HELPER FUNCTIONS #############################################################
 ################################################################################
 
+
 def get_lookup():
-    '''get version by way of singularity.version, returns a 
+    '''get version by way of singularity.version, returns a
     lookup dictionary with several global variables without
     needing to import singularity
     '''
@@ -28,12 +28,13 @@ def get_lookup():
         exec(filey.read(), lookup)
     return lookup
 
+
 # Read in requirements
 def get_requirements(lookup=None, key="INSTALL_REQUIRES"):
     '''get_requirements reads in requirements and versions from
     the lookup obtained with get_lookup'''
 
-    if lookup == None:
+    if lookup is None:
         lookup = get_lookup()
 
     install_requires = []
@@ -41,19 +42,19 @@ def get_requirements(lookup=None, key="INSTALL_REQUIRES"):
         module_name = module[0]
         module_meta = module[1]
         if "exact_version" in module_meta:
-            dependency = "%s==%s" %(module_name,module_meta['exact_version'])
+            dependency = "%s==%s" % (module_name, module_meta['exact_version'])
         elif "min_version" in module_meta:
-            if module_meta['min_version'] == None:
+            min_version = module_meta['min_version']
+            if min_version is None:
                 dependency = module_name
             else:
-                dependency = "%s>=%s" %(module_name,module_meta['min_version'])
+                dependency = "%s>=%s" % (module_name, min_version)
         install_requires.append(dependency)
     return install_requires
 
 
-
 # Make sure everything is relative to setup.py
-install_path = os.path.dirname(os.path.abspath(__file__)) 
+install_path = os.path.dirname(os.path.abspath(__file__))
 os.chdir(install_path)
 
 # Get version information from the lookup
@@ -76,8 +77,13 @@ with open('README.md') as filey:
 
 if __name__ == "__main__":
 
+    # Install all exporters and/or watchers
     INSTALL_REQUIRES = get_requirements(lookup)
-    URLS_DYNAMIC = get_requirements(lookup,'INSTALL_URLS_DYNAMIC')
+    INSTALL_ALL = get_requirements(lookup, 'INSTALL_ALL')
+    WATCHERS = get_requirements(lookup, 'INSTALL_WATCHERS')
+
+    # Watchers
+    URLS_DYNAMIC = get_requirements(lookup, 'INSTALL_URLS_DYNAMIC')
     PSUTILS = get_requirements(lookup, 'INSTALL_PSUTILS')
 
     setup(name=NAME,
@@ -86,7 +92,7 @@ if __name__ == "__main__":
           author_email=AUTHOR_EMAIL,
           maintainer=AUTHOR,
           maintainer_email=AUTHOR_EMAIL,
-          packages=find_packages(), 
+          packages=find_packages(),
           include_package_data=True,
           zip_safe=False,
           url=PACKAGE_URL,
@@ -96,11 +102,12 @@ if __name__ == "__main__":
           keywords=KEYWORDS,
           setup_requires=["pytest-runner"],
           tests_require=["pytest"],
-          install_requires = INSTALL_REQUIRES,
+          install_requires=INSTALL_REQUIRES,
           extras_require={
-              'all': [INSTALL_REQUIRES],
-              'urls-dynamic': [URLS_DYNAMIC],
-              'psutils': [PSUTILS]
+              'all': [INSTALL_ALL],
+              'watchers': [WATCHERS],
+              'watcher-urls-dynamic': [URLS_DYNAMIC],
+              'watcher-psutils': [PSUTILS]
           },
           classifiers=[
               'Intended Audience :: Science/Research',
@@ -113,4 +120,4 @@ if __name__ == "__main__":
               'Programming Language :: Python :: 3',
           ],
 
-          entry_points = {'console_scripts': [ 'watchme=watchme.client:main' ] })
+          entry_points={'console_scripts': ['watchme=watchme.client:main']})

--- a/watchme/client/__init__.py
+++ b/watchme/client/__init__.py
@@ -112,7 +112,7 @@ def get_parser():
 
     # add
 
-    add = subparsers.add_parser("add",
+    add = subparsers.add_parser("add-task",
                                  help="add a task to a watcher.")
 
     add.add_argument('watcher', nargs=1,
@@ -150,6 +150,10 @@ def get_parser():
 
     ls = subparsers.add_parser("list",
                                help="list all watchers at a base")
+
+    ls.add_argument('--watchers', dest="watchers", 
+                     help="list watchers available", 
+                     default=False, action='store_true')
 
     # protect and freeze
 
@@ -305,7 +309,7 @@ def main():
         sys.exit(0)
 
     if args.command == "activate": from .activate import main
-    elif args.command == "add": from .add import main
+    elif args.command == "add-task": from .add import main
     elif args.command == "edit": from .edit import main
     elif args.command == "export": from .export import main
     elif args.command == "create": from .create import main

--- a/watchme/client/add.py
+++ b/watchme/client/add.py
@@ -12,14 +12,14 @@ from watchme import get_watcher
 from watchme.logger import bot
 
 def main(args, extra):
-    '''activate one or more watchers
+    '''add a task for a watcher
     '''    
     # Required - will print help if not provided
     name = args.watcher[0]
     task = args.task[0]
 
     if not task.startswith('task'):
-        example = 'watchme add watcher task-cpu func@cpu_task type@psutils'
+        example = 'watchme add-task watcher task-cpu func@cpu_task type@psutils'
         bot.exit('Task name must start with "task", e.g., %s' % example)
 
     # Exit if the user doesn't provide any parameters

--- a/watchme/client/create.py
+++ b/watchme/client/create.py
@@ -20,4 +20,3 @@ def main(args, extra):
 
     for watcher in watchers:
         create_watcher(watcher)
-    

--- a/watchme/client/export.py
+++ b/watchme/client/export.py
@@ -15,7 +15,7 @@ import json
 import os
 
 def main(args, extra):
-    '''activate one or more watchers
+    '''export temporal data for a watcher
     '''    
     # Required - will print help if not provided
     name = args.watcher[0]
@@ -23,7 +23,7 @@ def main(args, extra):
     filename = args.filename[0]
 
     if not task.startswith('task'):
-        example = 'watchme add watcher task-reddit url@https://www.reddit.com'
+        example = 'watchme export watcher task-reddit result.txt'
         bot.exit('Task name must start with "task", e.g., %s' % example)
 
     # Use the output file, or a temporary file

--- a/watchme/client/ls.py
+++ b/watchme/client/ls.py
@@ -10,16 +10,25 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from watchme.command import (
     get_watchers,
-    list_watcher
+    list_watcher,
+    list_watcher_types
 )
 from watchme.logger import bot
 
 def main(args, extra):
     '''list installed watchers
-    '''    
-    if extra == None:
-        get_watchers(args.base)
-    else:
-        for watcher in extra:
-            list_watcher(watcher, args.base)
+    '''
+    if args.watchers == True:
+        list_watcher_types()
 
+    # Otherwise, we are listing installed watchers and tasks
+    else:
+
+        # If no watchers provided, list the watchers
+        if extra == None:
+            get_watchers(args.base)
+
+        # Otherwise, list the tasks of the watcher
+        else:
+            for watcher in extra:
+                list_watcher(watcher, args.base)

--- a/watchme/command/__init__.py
+++ b/watchme/command/__init__.py
@@ -26,5 +26,6 @@ from .commit import (
 )
 from .utils import (
     get_watchers,
-    list_watcher
+    list_watcher,
+    list_watcher_types
 )

--- a/watchme/command/create.py
+++ b/watchme/command/create.py
@@ -27,6 +27,7 @@ def create_watcher(name=None, watcher_type=None, base=None):
        name: the watcher to create, uses default or WATCHME_WATCHER
        watcher_type: the type of watcher to create. defaults to 
                      WATCHER_DEFAULT_TYPE
+        base: The watcher base to use (defaults to $HOME/.watchme)
     '''
     if name == None:
         name = WATCHME_WATCHER

--- a/watchme/command/utils.py
+++ b/watchme/command/utils.py
@@ -8,7 +8,11 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 '''
 
-from watchme.defaults import WATCHME_BASE_DIR
+from watchme.defaults import (
+    WATCHME_BASE_DIR, 
+    WATCHME_TASK_TYPES
+)
+
 from watchme.utils import ( get_tmpdir, run_command )
 from watchme.logger import bot
 
@@ -54,6 +58,13 @@ def list_watcher(watcher, base=None):
         bot.info('\n  '.join(files))
     else:
         bot.exit('%s does not exist.' % base)
+
+def list_watcher_types():
+    '''list the exporter options provided by watchme
+    '''
+    bot.custom(prefix="watchme:", message="watcher task types", color="CYAN")
+    bot.info('\n  '.join(WATCHME_TASK_TYPES))
+
 
 def clone_watcher(repo, base=None, name=None):
     '''clone a watcher from Github (or other version control with git)

--- a/watchme/version.py
+++ b/watchme/version.py
@@ -6,13 +6,13 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.16"
+__version__ = "0.0.17"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'watchme'
 PACKAGE_URL = "http://www.github.com/vsoch/watchme"
-KEYWORDS = 'web, changes, cron'
-DESCRIPTION = "client to watch for webpage changes, and track over time"
+KEYWORDS = 'web, changes, cron, reproducible, version-control'
+DESCRIPTION = "reproducible monitoring client with exporters"
 LICENSE = "LICENSE"
 
 INSTALL_REQUIRES = (
@@ -31,6 +31,12 @@ INSTALL_PSUTILS = (
     ('psutil', {'min_version': '5.4.3'}),
 )
 
+# Install all watchers and exporters
 INSTALL_ALL = (INSTALL_REQUIRES +
                INSTALL_PSUTILS +
                INSTALL_URLS_DYNAMIC)
+
+# Install all watchers
+INSTALL_WATCHERS = (INSTALL_REQUIRES +
+                    INSTALL_PSUTILS +
+                    INSTALL_URLS_DYNAMIC)

--- a/watchme/watchers/README.md
+++ b/watchme/watchers/README.md
@@ -5,4 +5,10 @@ Each of these is a Watcher that the user can request.
  - [urls](urls) to watch for changes in websites (default)
  - [psutils](psutils) to get basic system statistics
 
-More watchers will be added as the library is developed.
+## Watcher Base
+
+The watcher base is defined in the [init](__init__.py) file here. 
+
+ - [schedules](schedule.py) to interact with cronjobs
+ - [exporters](data.py) (extras) and the default export of temporal data
+ - [settings](settings.py) meaning add/remove from the watchme.cfg

--- a/watchme/watchers/settings.py
+++ b/watchme/watchers/settings.py
@@ -96,10 +96,11 @@ def print_section(self, section):
     else:
         bot.exit('%s is not a valid section.' % section)
 
-def get_setting(self, section, name, default=None):
-    '''return a setting from the environment (first priority) and then
-       secrets (second priority) if one can be found. If not, return None.
 
+def get_setting(self, section, name, default=None):
+    '''return a setting from the config, if defined. Otherwise return
+       default (None or set by user)
+       
        Parameters
        ==========
        section: the section in the config, defaults to self.name
@@ -119,6 +120,31 @@ def get_setting(self, section, name, default=None):
     return setting
 
 
+def has_setting(self, section, name):
+    '''return a boolean if a config has a setting (or not)
+       Parameters
+       ==========
+       section: the section in the config, defaults to self.name
+       name: they key (index) of the setting to look up
+    ''' 
+    self.load_config()
+
+    exists = False
+    if section in self.config:
+         if name.lower() in self.config[section]:
+            exists = True
+
+    return exists
+
+
+def has_section(self, section):
+    '''return a boolean if a config has a section (e.g., a task or exporter)
+       Parameters
+       ==========
+       section: the section in the config
+    ''' 
+    self.load_config()
+    return section in self.config
 
 def set_setting(self, section, key, value):
     '''set a key value pair in a section, if the section exists. Returns
@@ -145,6 +171,6 @@ def get_section(self, name):
     '''
     section = None
     self.load_config()
-    if name in self.config.sections():
+    if name in self.config:
         section = self.config[name]
     return section

--- a/watchme/watchers/urls/helpers.py
+++ b/watchme/watchers/urls/helpers.py
@@ -11,6 +11,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import os
 import tempfile
 import requests
+import re
 
 # Helper functions
 


### PR DESCRIPTION
This pull request will re-organize the task base to include a single entrypoint to the functions to write data to file. I made this decision based on doing similar in #32, which I'm not sure is going to be merged, and wanted to maintain the nice organization here. Specifically, instead of having custom parsing done by the watcher, we allow it to be run (and then custom defined) by the task. This way, a special kind of task can choose to parse data in a custom way.

I'm also experimenting with flake8, and am considering adding it (but possibly after this merge to not be too much in one PR). 

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>