### PR TITLE
adding results watcher - first from the environment

### DIFF
--- a/docs/_docs/watcher-tasks/index.md
+++ b/docs/_docs/watcher-tasks/index.md
@@ -14,3 +14,4 @@ We just have support for watching web urls, task type "urls":
 
  - [urls]({{ site.baseurl }}/watchers/urls/) to watch for changes in web content
  - [psutils]({{ site.baseurl }}/watchers/psutils) to monitor system, sensors, python, and network
+ - [results]({{ site.baseurl }}/watchers/results) to record results

--- a/docs/_docs/watcher-tasks/results.md
+++ b/docs/_docs/watcher-tasks/results.md
@@ -1,0 +1,129 @@
+---
+title: results
+category: Watcher Tasks
+permalink: /watchers/results/
+order: 3
+---
+
+The results watcher is optimized to use WatchMe as a database. The various
+functions coincide with where data is expected to come from, and there
+is flexibility to customize format and file naming. You don't need
+any extra dependencies to use it, other than having watchme installled.
+
+```bash
+$ pip install watchme
+```
+
+Next, create a watcher for your tasks to live under:
+
+```bash
+$ watchme create results-watcher
+```
+
+Now let's walk through each of the tasks. If you aren't familiar with how
+to add a task and otherwise manage them, see the [getting started]({{ site.baseurl }}/getting-started/)
+docs. Here are the functions exposed by the results group:
+
+ - [From Environment](#the-from-env-task)
+
+## Add a Task
+
+We are going to be added tasks to our watcher, "results-watcher" above.
+The general format to add a task looks like this:
+
+```bash
+$ watchme add-task <watcher> <task-name> key1@value1 key2@value2
+```
+
+The key and value pairs are going to vary based on the watcher task.
+
+### 1. The From Env Task
+
+This task does exactly what it sounds like - it finds results from the environment.
+You can specify it to watchme via `func@from_env_task`
+
+```bash
+$ watchme add-task results-watcher task-hpc-job --type results func@from_env_task
+func  = from_env_task
+active  = true
+type  = results
+```
+
+The task itself is really simple - it's going to scrape the environment
+for variables that begin with `WATCHMEENV_`. Let's say that I'm running a job
+on my research cluster, the process could export some number of results, let's
+say one is a density and the other is a weight.
+
+```
+export WATCHMEENV_density=0.45
+export WATCHMEENV_weight=32
+```
+
+The export makes the variables available to any child processes of the job, but
+they won't leak into other running processes. I might finish running the job, 
+and then have watchme issue a command directly to save the result. Let's
+activate the watcher to test it out:
+
+```bash
+$ watchme activate results-watcher
+```
+
+And here you can export any number of `WATCHMEENV_` variables in your environment, and then
+run watchme like this to test:
+
+```bash
+$ watchme run results-watcher task-hpc-job
+```
+
+The task will find the environment variables, and then save the results to
+the GitHub repository according to the environment variable name under
+the task folder. In this case we would see:
+
+```
+$ tree task-hpc-job/
+task-hpc-job/
+├── density
+├── TIMESTAMP
+└── weight
+```
+
+How cool is that! You could use this so that each timepoint represents
+a single database entry (and for example, export a `WATCHMEENV_ID` to
+provide an identifier for the unit) or you could have each environment
+variable coincide with the same measurment, perhaps changing over time. 
+Take a look at the git log too - you'll see that every change and entry
+is recorded for you, and ready to push to GitHub to share.
+
+The cool thing about this task is that you likely wouldn't want to schedule it
+to run, you would have it run after or during some job or process that you
+want to record. Just for example, let's export another set of values,
+and then show you how to export the entire data structure for each file:
+
+```bash
+export WATCHMEENV_density=0.55
+export WATCHMEENV_weight=34
+watchme run results-watcher task-hpc-job
+```
+
+To export data, the format is:
+
+```bash
+$ watchme export results-watcher task-hpc-job density
+git log --all --oneline --pretty=tformat:"%H" --grep "ADD results" 384d7bdc6e54af6266377b30ff0d47a40c4fc28d..732dee443caa19f0e50ec1e9b89ca3a542459cc7 -- task-hpc-job/density
+{
+    "commits": [
+        "732dee443caa19f0e50ec1e9b89ca3a542459cc7",
+        "c0861ed8ebe473cc3efa1db5f84e10d05d61bbc8"
+    ],
+    "dates": [
+        "2019-05-08 15:16:14 -0400",
+        "2019-05-08 15:11:32 -0400"
+    ],
+    "content": [
+        "0.55",
+        "0.45"
+    ]
+}
+```
+
+There you go!

--- a/watchme/defaults.py
+++ b/watchme/defaults.py
@@ -57,7 +57,7 @@ WATCHME_WORKERS = int(getenv('WATCHME_WORKERS', 9))
 
 # The types of valid watchers (currently only urls). Corresponds with
 # a folder under "main/watchers"
-WATCHME_TASK_TYPES = ['urls', 'url', 'psutils']
+WATCHME_TASK_TYPES = ['urls', 'url', 'psutils', 'results']
 WATCHME_DEFAULT_TYPE = "urls"
 
 # Parameters not allowed for task clients, set by TaskBase

--- a/watchme/tasks/__init__.py
+++ b/watchme/tasks/__init__.py
@@ -127,7 +127,7 @@ class TaskBase(object):
             result = [r for r in result if r]
 
             if len(result) == 0:
-                bot.error('%s returned empty list of results.' % name)
+                bot.error('%s returned empty list of results.' % self.name)
 
             # json output is specified
             elif self.params.get('save_as') == 'json':
@@ -203,6 +203,7 @@ class TaskBase(object):
 
         return files
 
+
     def _save_text(self, result, repo, file_name=None):
         '''save a general text object to file.
  
@@ -216,6 +217,7 @@ class TaskBase(object):
         destination = os.path.join(task_folder, file_name)
         write_file(destination, result)
         return destination
+
 
     def _save_file(self, result, repo, file_name=None):
         '''for a result that exists, move the file to final destination.
@@ -238,6 +240,7 @@ class TaskBase(object):
             return os.path.join(name, file_name)
 
         bot.warning('%s does not exist.' % result)
+
         
     def _save_json(self, result, repo, file_name=None):
         '''for a result that is a dictionary or list, save as json
@@ -251,6 +254,23 @@ class TaskBase(object):
         write_json(result, destination)
         return destination
 
+
+    def _save_files_list(self, results, repo):
+        '''If the user provides already existing files, we simply move them
+           into the task folder in the repository.
+ 
+           Parameters
+           ==========
+           results: the results to save, should a list of files
+        '''
+        files = []
+        for result in results:
+            filename = os.path.basename(result)
+            filename = os.path.join(repo, self.name, filename)
+            shutil.move(result, filename) 
+            files.append(filename)
+
+        return files
 
     def _save_json_list(self, results, repo):
         '''A wrapper around save json for a list, handles file naming.

--- a/watchme/version.py
+++ b/watchme/version.py
@@ -6,7 +6,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.17"
+__version__ = "0.0.18"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'watchme'

--- a/watchme/watchers/__init__.py
+++ b/watchme/watchers/__init__.py
@@ -265,9 +265,11 @@ class Watcher(object):
         if task_type.startswith('url'):
             from .urls import Task
 
-        # Validate variables provided for task
         elif task_type == 'psutils':
             from .psutils import Task
+
+        elif task_type == 'results':
+            from .results import Task
 
         else:
             bot.exit('task_type %s not properly added to Watcher' % task_type)
@@ -583,6 +585,9 @@ class Watcher(object):
 
             elif task_type == 'psutils':
                 from .psutils import Task
+
+            elif task_type == 'results':
+                from .results import Task
 
             else:
                 bot.exit('Type %s not properly set up in get_task' % task_type)

--- a/watchme/watchers/results/__init__.py
+++ b/watchme/watchers/results/__init__.py
@@ -1,0 +1,46 @@
+'''
+
+Copyright (C) 2019 Vanessa Sochat.
+
+This Source Code Form is subject to the terms of the
+Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+'''
+
+from watchme.tasks import TaskBase
+from watchme.logger import bot
+from watchme.utils import ( get_user, get_host )
+import os
+import sys
+
+class Task(TaskBase):
+    '''a results task aims to use WatchMe as a database, meaning the functions
+       are optimized to collect and record results.'''
+
+    required_params = []
+
+    def __init__(self, name, params={}, **kwargs): 
+
+        self.type = 'results'
+
+        # Handles setting the name, setting params, and validate
+        super(Task, self).__init__(name, params, **kwargs)
+
+    def export_func(self):
+        '''this function should return the correct task (from the tasks.py
+           in the same folder) based on some logic of the params that are given
+           by the user (self.params). If there is only one kind of function for
+           the task, it's fairly easy to import and return it here. This
+           function should take no arguments, but instead use the self.params
+           already provided in the client.
+        '''
+        name = self.params.get('func', 'from_env_task')
+
+        if name == 'from_env_task':
+            from .tasks import from_env_task as func
+        else:
+            func = None
+
+        return func

--- a/watchme/watchers/results/tasks.py
+++ b/watchme/watchers/results/tasks.py
@@ -1,0 +1,60 @@
+'''
+
+Copyright (C) 2019 Vanessa Sochat.
+
+This Source Code Form is subject to the terms of the
+Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+'''
+
+from watchme.utils import (
+    get_tmpdir,
+    write_file
+)
+import os
+import re
+import shutil
+
+
+def from_env_task(**kwargs):
+    '''Get some set of variables from the environment. We look for those
+       defined in kwargs, but also any in the environment that start with
+       the prefix WATCHMENEV_. They are saved to files that are equivalently
+       named, and the idea is that we can track a changing (single) result,
+       meaning that the timestamp is meaningful, or we can track
+       values for many different results, so the timestamps just serve to
+       record when each was recorded.
+
+       Parameters
+       ==========
+       *: any number of parameters from the task configuration that will
+          be looked for in the environment.
+    '''
+    results = []
+ 
+    # Create a temporary directory for results
+    tmpdir = get_tmpdir()
+
+    # First extract variables from the environment
+    for key, value in os.environ.items():
+
+        # Variables that are specified, or start with WATCHMEENV included
+        if key.startswith("WATCHMEENV_"):
+
+            # Replace the WATCHMEENV_ if present
+            key = re.sub("^WATCHMEENV_", "", key)
+
+            # Don't include empty strings
+            if value not in ["", None]:
+
+                # Write the result to file (don't include extension)
+                filename = os.path.join(tmpdir, key)
+                write_file(filename, value)
+                results.append(filename)
+
+    # If no results, return None
+    if len(results) == 0:
+        shutil.rmtree(tmpdir)
+
+    return results


### PR DESCRIPTION
This is a really cool watcher that will allow a user (via any kind of process) to export any number of environment variables (variables and values) and then save them to .git as a database! I'm attaching the complete tutorial written in the docs as an example. I'm going to think about if there are more kinds of places we can get results from (e.g., the run command would need to accept some other kind of input, which I'm hesitant to do) so this might be it for now :)

Here are the docs showing how it works!

[results _ watchme.pdf](https://github.com/vsoch/watchme/files/3158968/results._.watchme.pdf)


Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>