### PR TITLE
Fixing print to add task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Critical items to know are:
  - changed behaviour
 
 ## [master](https://github.com/vsoch/watchme/tree/master)
+ - Print of task should be "add-task" (0.0.21)
  - Custom WATCHME_ENV variables added to monitoring decorator/task (0.0.20)
  - Adding decorator for system (psutils) monitoring (0.0.19)
  - Reorganizing task functions to belong with TaskBase (0.0.17)

--- a/watchme/version.py
+++ b/watchme/version.py
@@ -6,7 +6,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.20"
+__version__ = "0.0.21"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'watchme'

--- a/watchme/watchers/settings.py
+++ b/watchme/watchers/settings.py
@@ -68,7 +68,7 @@ def print_add_task(self, task):
     self.load_config()
 
     if task in self.config:
-        command = "watchme add %s" % task
+        command = "watchme add-task %s" % task
         for key in self.config[task]:
             value = self.config[task][key]
             command = "%s %s@%s" %(command, key, value)


### PR DESCRIPTION
This is a work in progress PR to address issues brought up in #45 

 - inspect should print "add-task"

And more will be added after discussion.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>