### PR TITLE
Add terminal monitor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ test_watchme_python: &test_watchme_python
         cd ~/repo/watchme/tests
         $HOME/conda/bin/python -m unittest test_client
         $HOME/conda/bin/python -m unittest test_utils
+        $HOME/conda/bin/python -m unittest test_decorators
 
 test_watchme_bash: &test_watchme_bash
   name: Test WatchMe Client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Critical items to know are:
  - changed behaviour
 
 ## [master](https://github.com/vsoch/watchme/tree/master)
+ - Adding terminal monitor command group (0.0.22)
  - Print of task should be "add-task" (0.0.21)
  - Custom WATCHME_ENV variables added to monitoring decorator/task (0.0.20)
  - Adding decorator for system (psutils) monitoring (0.0.19)

--- a/docs/_docs/watcher-tasks/psutils.md
+++ b/docs/_docs/watcher-tasks/psutils.md
@@ -222,7 +222,12 @@ $ watchme monitor sleep 2 --only cmdline
 ```
 
 Notice that your custom environment variables are not skipped, only those
-in the content of the default parameters. ANd there you have it! With these methods to monitor any process on the fly at
+in the content of the default parameters.  Here is a rundown of all of what
+is discussed above:
+
+<script id="asciicast-247000" src="https://asciinema.org/a/247000.js" data-speed="2" async></script>
+
+And there you have it! With these methods to monitor any process on the fly at
 a particular interval, you are good to go! 
 
 

--- a/docs/_docs/watcher-tasks/psutils.md
+++ b/docs/_docs/watcher-tasks/psutils.md
@@ -82,6 +82,150 @@ Either way, you will want to create your watcher first:
 $ watchme create system
 ```
 
+#### Run on the Fly, Python
+
+It's most likely you want to run and monitor a command on the fly, either from
+within Python or the command line. First, let's take a look at running from
+within Python. We are going to use a `TerminalRunner` to run the command:
+
+```python
+from watchme.watchers.decorators import TerminalRunner
+runner = TerminalRunner('sleep 5')
+runner.run()
+timepoints = runner.wait()
+```
+
+You'll get a list of timepoints, collected at intervals of 3 seconds! Here
+is the top of the first:
+
+```python
+[{'SECONDS': '3',
+  'cmdline': ['sleep', '5'],
+  'connections': [],
+  'cpu_affinity': [0, 1, 2, 3],
+  'cpu_num': 1,
+  'cpu_percent': 0.0,
+  'cpu_times': {'children_system': 0.0,
+...
+```
+
+Do you need to add data to the structure? Just export it with prefix `WATCHMEENV_*`
+
+```python
+os.environ['WATCHMEENV_AVOCADO'] = '5'
+```
+
+and it will appear in the result!
+
+```python
+ {'AVOCADO': '5',
+  'SECONDS': '3',
+  'cmdline': ['sleep', '5'],
+  'connections': [],
+  'cpu_affinity': [0, 1, 2, 3],
+  'cpu_num': 3,
+...
+```
+
+If you want to skip fields, include fields, or use "only" a subset of the keys
+returned in the default result, you can define lists for `only`, `include`,
+and `skip` to the `TerminalRunner` directly (optional).
+
+#### Run on the Fly, Command Line
+
+If you choose, the same function can be run via the watchme command line client.
+If you provide no additional arguments, it will print the data structure to
+the screen:
+
+```bash
+$ watchme monitor sleep 2
+[{'cpu_percent': 0.0, 'io_counters': {'read_count': 6, 'write_count': 0, 'read_bytes': 0, 'write_bytes': 0, 'read_chars': 1948, 'write_chars': 0}, 'cmdline': ['sleep', '2'], 'name': 'sleep', 'ppid': 26261, 'cwd': '/home/vanessa/Desktop/watchme', 'open_files': 0, 'ionice': {'ioclass': 'IOPRIO_CLASS_NONE', 'value': 4}, 'exe': '/bin/sleep', 'create_time': 1558125191.98, 'num_threads': 1, 'status': 'sleeping', 'pid': 26264, 'memory_full_info': {'rss': 663552, 'vms': 7467008, 'shared': 589824, 'text': 28672, 'lib': 0, 'data': 323584, 'dirty': 0, 'uss': 118784, 'pss': 133120, 'swap': 0}, 'gids': {'real': 1000, 'effetive': 1000, 'saved': 1000}, 'num_fds': 3, 'num_ctx_switches': {'voluntary': 1, 'involuntary': 1}, 'memory_percent': 0.00317349248332839, 'nice': 0, 'cpu_affinity': [0, 1, 2, 3], 'cpu_times': {'user': 0.0, 'system': 0.0, 'children_user': 0.0, 'children_system': 0.0}, 'connections': [], 'terminal': '/dev/pts/18', 'cpu_num': 1, 'uids': {'real': 1000, 'effetive': 1000, 'saved': 1000}, 'username': 'vanessa', 'SECONDS': '3'}]
+```
+
+Want to add an environment variable? The same applies - you can export `WATCHMEENV_*` and they
+will be added to results.
+
+```bash
+$ export WATCHMEENV_AVOCADOS=3
+$ watchme monitor sleep 2
+[{'ppid': 26273, 'username': 'vanessa', 'cmdline': ['sleep', '2'], 'gids': {'real': 1000, 'effetive': 1000, 'saved': 1000}, 'io_counters': {'read_count': 6, 'write_count': 0, 'read_bytes': 0, 'write_bytes': 0, 'read_chars': 1948, 'write_chars': 0}, 'cpu_num': 3, 'nice': 0, 'ionice': {'ioclass': 'IOPRIO_CLASS_NONE', 'value': 4}, 'pid': 26276, 'num_ctx_switches': {'voluntary': 1, 'involuntary': 0}, 'status': 'sleeping', 'name': 'sleep', 'create_time': 1558125219.84, 'cpu_affinity': [0, 1, 2, 3], 'num_fds': 3, 'cpu_times': {'user': 0.0, 'system': 0.0, 'children_user': 0.0, 'children_system': 0.0}, 'open_files': 0, 'cpu_percent': 0.0, 'uids': {'real': 1000, 'effetive': 1000, 'saved': 1000}, 'memory_full_info': {'rss': 700416, 'vms': 7467008, 'shared': 626688, 'text': 28672, 'lib': 0, 'data': 323584, 'dirty': 0, 'uss': 118784, 'pss': 133120, 'swap': 0}, 'memory_percent': 0.0033497976212910788, 'connections': [], 'cwd': '/home/vanessa/Desktop/watchme', 'num_threads': 1, 'exe': '/bin/sleep', 'terminal': '/dev/pts/18', 'AVOCADOS': '3', 'SECONDS': '3'}]
+```
+
+If you want to save to a watcher, then provide the watcher name as the first argument.
+For example, here we run a task on the fly, and save the result to the watcher "decorator."
+Since we don't provide a `--name` argument, the name defaults to a derivation of the command run.
+
+```bash
+$ watchme monitor decorators sleep 2
+$ WATCHMEENV_AVOCADOS=3 watchme monitor decorator sleep 2
+```
+
+List the folders in the watcher named "decorator" to see the newly added result:
+
+
+```bash
+$ watchme list decorator
+watcher: /home/vanessa/.watchme/decorator
+task-monitor-slack
+  decorator-psutils-sleep-2
+  .git
+  decorator-psutils-noenv
+  decorator-psutils-myfunc
+  watchme.cfg
+```
+
+And then use export to export the data!
+
+```bash
+$ watchme export decorator decorator-psutils-sleep-2 result.json --json
+git log --all --oneline --pretty=tformat:"%H" --grep "ADD results" 7a7cb5535c96e06433af9c47485ba253137e580f..b8f155c66819a646405cd710eca150396118fe7c -- decorator-psutils-sleep-2/result.json
+{
+    "commits": [
+        "b8f155c66819a646405cd710eca150396118fe7c"
+    ],
+    "dates": [
+        "2019-05-17 16:47:19 -0400"
+    ],
+    "content": [
+        {
+            "memory_full_info": {
+                "rss": 688128,
+                "vms": 7467008,
+                "shared": 614400,
+                "text": 28672,
+                "lib": 0,
+                "data": 323584,
+...
+```
+
+For both of the command line above, you can define `--name` to give
+a custom name, or `--seconds` to set the interval at which to collect metrics
+(default is 3).
+
+```bash
+$ watchme monitor sleep 2 --seconds 1
+```
+
+And along with the interactive Python version, you can optionally specify
+a comma separated value string of keys to include, skip, or only use.
+Here we skip two fields:
+
+```bash
+$ watchme monitor sleep 2 --skip memory_full_info,cmdline
+```
+
+And here we only care about the command line:
+
+```bash
+$ watchme monitor sleep 2 --only cmdline
+[{'cmdline': ['sleep', '2'], 'SECONDS': '3'}]
+```
+
+Notice that your custom environment variables are not skipped, only those
+in the content of the default parameters. ANd there you have it! With these methods to monitor any process on the fly at
+a particular interval, you are good to go! 
+
+
 #### Run as a Task
 
 To run as a task, you will want to provide `func@monitor_pid_task` when you create the task. 

--- a/docs/_docs/watcher-tasks/psutils.md
+++ b/docs/_docs/watcher-tasks/psutils.md
@@ -89,7 +89,7 @@ within Python or the command line. First, let's take a look at running from
 within Python. We are going to use a `TerminalRunner` to run the command:
 
 ```python
-from watchme.watchers.decorators import TerminalRunner
+from watchme.watchers.psutils.decorators import TerminalRunner
 runner = TerminalRunner('sleep 5')
 runner.run()
 timepoints = runner.wait()

--- a/watchme/client/__init__.py
+++ b/watchme/client/__init__.py
@@ -155,6 +155,39 @@ def get_parser():
                      help="list watchers available", 
                      default=False, action='store_true')
 
+
+    # monitor
+
+    monitor = subparsers.add_parser("monitor",
+                                    help="terminal process monitor (akin to time)")
+
+    monitor.add_argument('watcher', nargs="?",
+                         help='the watcher to run (if save desired)')
+
+    monitor.add_argument('--name', dest="name", 
+                         help="a custom name for the output folder (decorator-<name>)", 
+                         default=None, type=str)
+
+    monitor.add_argument('--skip', dest="skip", 
+                         help="keys in result to skip", 
+                         default=None, type=str)
+
+    monitor.add_argument('--only', dest="only", 
+                         help="only include these values", 
+                         default=None, type=str)
+
+    monitor.add_argument('--include', dest="include", 
+                         help="keys in result to add back in (environ)", 
+                         default=None, type=str)
+
+    monitor.add_argument('--seconds', '-s', dest="seconds", 
+                         help="interval (seconds) to monitor at", 
+                         default=3, type=int)
+
+    monitor.add_argument('--test', dest="test", 
+                         help="run monitor in test mode (for a decorator, no save)", 
+                         default=False, action='store_true')
+
     # protect and freeze
 
     protect = subparsers.add_parser("protect",
@@ -318,6 +351,7 @@ def main():
     elif args.command == "init": from .init import main
     elif args.command == "inspect": from .inspect import main
     elif args.command == "list": from .ls import main
+    elif args.command == "monitor": from .monitor import main
     elif args.command == "protect": from .protect import main
     elif args.command == "remove": from .remove import main
     elif args.command == "run": from .run import main

--- a/watchme/client/monitor.py
+++ b/watchme/client/monitor.py
@@ -1,0 +1,53 @@
+'''
+
+Copyright (C) 2019 Vanessa Sochat.
+
+This Source Code Form is subject to the terms of the
+Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+'''
+
+from watchme.logger import bot
+from watchme.command import get_watchers
+from watchme import get_watcher
+from watchme.watchers.psutils.decorators import TerminalRunner
+
+def main(args, extra):
+    '''monitor a task (from the command line), meaning wrapping it with
+       multiprocessing, getting the id, and returning a result (command line 
+       or written to file)
+    '''  
+    # The first argument will either be part of a command, or a watcher
+    watcher = args.watcher
+
+    # The entire user command is the extra arguments
+    command = extra
+
+    # If the user provides a watcher, we are saving to it
+    if watcher not in get_watchers(args.base, quiet=True):       
+        command = [watcher] + command
+        watcher = None
+    else:
+        watcher = get_watcher(watcher, base=args.base, create=False)
+
+    command = ' '.join(command)
+    runner = TerminalRunner(command, 
+                            skip=args.skip,
+                            include=args.include,
+                            only=args.only,
+                            seconds=args.seconds)
+    runner.run()
+    timepoints = runner.wait()
+
+    # If we don't have a watcher, print to terminal
+    if watcher is None or args.test is True:
+        print(timepoints)
+
+    # Otherwise save to watcher task folder
+    else:
+        name = args.name
+        if name == None:
+            name = command.replace(' ', '-')
+        name = 'decorator-psutils-%s' % name
+        watcher.finish_runs({name: timepoints})

--- a/watchme/tasks/decorators.py
+++ b/watchme/tasks/decorators.py
@@ -1,0 +1,52 @@
+'''
+
+Copyright (C) 2019 Vanessa Sochat.
+
+This Source Code Form is subject to the terms of the
+Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+'''
+
+from watchme.logger import bot
+import os
+
+class DecoratorBase(object):
+
+    def __init__(self, seconds=3, skip=[], include=[], only=[]):
+
+        self.seconds = seconds
+        self.timepoints = []
+
+        # Export seconds to the environment
+        os.environ["WATCHMEENV_SECONDS"] = str(self.seconds)
+
+        # Ensure we have csv lists
+        self.only = self._parse_custom(only)
+        self.skip = self._parse_custom(skip)
+        self.include = self._parse_custom(include)
+
+    def _parse_custom(self, listy):
+        '''parse an actual list (['one','two','three']) into 
+           a csv list. If we don't have a list, ignore and assume already
+           parsed that way.
+ 
+           Parameters
+           ==========
+           listy: the actual list
+        '''
+        if listy == None:
+            listy = []
+        if isinstance(listy, list):
+            listy = ','.join(listy)
+        return listy
+
+    def run(self, *args, **kwargs):
+        '''run should be implemented by the subclass to run the function or
+           process being monitored
+        '''
+        bot.exit('run function must be implemented by subclass.')
+
+    def wait(self, *args, **kwargs):
+        '''wait should be run after run to monitor the process being run.'''
+        bot.exit('wait function must be implemented by subclass.')

--- a/watchme/tests/test_client.sh
+++ b/watchme/tests/test_client.sh
@@ -81,5 +81,17 @@ runTest 0 $output watchme run github task-expfactory --no-progress
 runTest 0 $output watchme run github task-expfactory --serial
 runTest 0 $output watchme run github task-doesntexist
 
+echo "#### Testing watchme monitor"
+runTest 0 $output watchme monitor sleep 2
+runTest 0 $output watchme monitor github sleep 2
+runTest 0 $output test -d "$tmpdir/github/decorator-psutils-sleep-2"
+runTest 0 $output test -f "$tmpdir/github/decorator-psutils-sleep-2/result.json"
+runTest 0 $output test -f "$tmpdir/github/decorator-psutils-sleep-2/TIMESTAMP"
+runTest 0 $output watchme monitor github sleep 2 --name avocado
+runTest 0 $output test -d "$tmpdir/github/decorator-psutils-avocado"
+runTest 0 $output test -f "$tmpdir/github/decorator-psutils-avocado/result.json"
+runTest 0 $output test -f "$tmpdir/github/decorator-psutils-avocado/TIMESTAMP"
+
+
 echo "Finish testing basic client"
 rm -rf ${tmpdir}

--- a/watchme/tests/test_decorators.py
+++ b/watchme/tests/test_decorators.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+
+# Copyright (C) 2019 Vanessa Sochat.
+
+# This Source Code Form is subject to the terms of the
+# Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+# with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from watchme import get_watcher
+from watchme.command import create_watcher
+import unittest
+import tempfile
+import shutil
+import json
+import os
+
+
+print("########################################################### test_client")
+
+
+class TestDecorators(unittest.TestCase):
+
+    def setUp(self):
+        self.base = tempfile.mkdtemp()
+        self.repo = create_watcher('pancakes', base=self.base)
+        self.cli = get_watcher('pancakes', base=self.base)
+        
+    def tearDown(self):
+        shutil.rmtree(self.base)
+
+    def test_psutils_monitor(self):
+        '''test creation function, and basic watcher config'''
+        print("Testing psutilsc.decorators.TerminalRunner")
+        from watchme.watchers.psutils.decorators import TerminalRunner
+        runner = TerminalRunner('sleep 2')
+        runner.run()
+        timepoints = runner.wait()
+        self.assertTrue(len(timepoints)==1)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/watchme/version.py
+++ b/watchme/version.py
@@ -6,7 +6,7 @@
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.21"
+__version__ = "0.0.22"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'watchme'

--- a/watchme/watchers/psutils/decorators.py
+++ b/watchme/watchers/psutils/decorators.py
@@ -77,7 +77,7 @@ class ProcessRunner(DecoratorBase):
         self.queue = Queue
 
         # Handles setting the seconds, skip, include, and only parameters
-        super(TerminalRunner, self).__init__(**kwargs)
+        super(ProcessRunner, self).__init__(**kwargs)
 
     @staticmethod
     def _wrapper(func, queue, args, kwargs):

--- a/watchme/watchers/psutils/decorators.py
+++ b/watchme/watchers/psutils/decorators.py
@@ -15,39 +15,69 @@ from multiprocessing import (
 from functools import wraps
 from watchme.logger import bot
 from watchme.watchers.psutils import Task
+from watchme.tasks.decorators import DecoratorBase
 from watchme import get_watcher
 from time import sleep
 import os
+import shlex
+import subprocess
+import threading
 
 
-class ProcessRunner():
+class TerminalRunner(DecoratorBase):
 
-    def __init__(self, seconds=3, skip=[], include=[], only=[]):
+    def __init__(self, cmd, **kwargs):
+        self.cmd = shlex.split(cmd)
         self.process = None
-        self.seconds = seconds
-        self.queue = Queue()
-        self.timepoints = []
 
-        # Export seconds to the environment
-        os.environ["WATCHMEENV_SECONDS"] = str(self.seconds)
+        # Handles setting the skip, include, and only parameters
+        super(TerminalRunner, self).__init__(**kwargs)
 
-        # Ensure we have csv lists
-        self.only = self._parse_custom(only)
-        self.skip = self._parse_custom(skip)
-        self.include = self._parse_custom(include)
-
-    def _parse_custom(self, listy):
-        '''parse an actual list (['one','two','three']) into 
-           a csv list. If we don't have a list, ignore and assume already
-           parsed that way.
- 
-           Parameters
-           ==========
-           listy: the actual list
+    def run(self):
+        '''run the user provided function
         '''
-        if isinstance(listy, list):
-            listy = ','.join(listy)
-        return listy
+        try:
+            self.process = subprocess.Popen(self.cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
+        except FileNotFoundError:
+            self.cmd.pop(0)
+            self.process = subprocess.Popen(self.cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
+
+    def wait(self):
+        '''wait should monitor the running task. run should be called first.
+        '''
+        # Parameters for the pid, and to skip sections of results
+        params = {"skip": self.skip,
+                  "pid": self.process.pid,
+                  "include": self.include,
+                  "only": self.only,
+                  'func': 'monitor_pid_task'}
+
+        # This particular decorator doesn't take input params
+        task = Task("monitor_pid_task", params=params)
+
+        # Export parameters and functions            
+        function = task.export_func()
+        params = task.export_params()
+
+        # collect resources, then sleep
+        while self.process.poll() == None:
+
+            # Function returns dictionary, we append to list of timepoints
+            self.timepoints.append(function(**params))
+            sleep(self.seconds)
+
+        # Get the timepoints
+        return self.timepoints
+
+
+class ProcessRunner(DecoratorBase):
+
+    def __init__(self, **kwargs):
+        self.process = None
+        self.queue = Queue
+
+        # Handles setting the seconds, skip, include, and only parameters
+        super(TerminalRunner, self).__init__(**kwargs)
 
     @staticmethod
     def _wrapper(func, queue, args, kwargs):
@@ -55,12 +85,16 @@ class ProcessRunner():
         queue.put(ret)
 
     def run(self, func, *args, **kwargs):
+        '''run the user provided function
+        '''
         args2 = [func, self.queue, args, kwargs]
         p = Process(target=self._wrapper, args=args2)
         self.process = p
         p.start()
 
     def wait(self):
+        '''watch should monitor the running task. run should be called first.
+        '''
 
         # Parameters for the pid, and to skip sections of results
         params = {"skip": self.skip,

--- a/watchme/watchers/psutils/decorators.py
+++ b/watchme/watchers/psutils/decorators.py
@@ -74,7 +74,7 @@ class ProcessRunner(DecoratorBase):
 
     def __init__(self, **kwargs):
         self.process = None
-        self.queue = Queue
+        self.queue = Queue()
 
         # Handles setting the seconds, skip, include, and only parameters
         super(ProcessRunner, self).__init__(**kwargs)

--- a/watchme/watchers/psutils/tasks.py
+++ b/watchme/watchers/psutils/tasks.py
@@ -71,8 +71,11 @@ def monitor_pid_task(**kwargs):
             continue
 
         # First priority goes to a custom set
-        if len(only) > 0 and key in only:
-            bot.debug('skipping %s' % key)
+        if len(only) > 0:
+            if key in only:
+                results[key] = val
+            else:
+                bot.debug('skipping %s' % key)
             continue 
 
         # The user requested to skip


### PR DESCRIPTION
This PR will expose the same monitoring commands for processes, but via the terminal command line! The user can also do the same directly in Python with the `TerminalRunner`. A preview of the command line version is here:

https://asciinema.org/a/247000?speed=2

And docs provided in the attached PDF.

[psutils _ watchme.pdf](https://github.com/vsoch/watchme/files/3193133/psutils._.watchme.pdf)
