### PR TITLE
Adding debugging page and noting that default type is json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,29 +37,6 @@ workflows:
                    echo "quay.io/vanessa/watchme:v${DOCKER_TAG}"
                    echo "quay.io/vanessa/watchme:py3-v${DOCKER_TAG}"
 
-      - docker-publish/publish:
-          image: vanessa/watchme
-          registry: quay.io
-          dockerfile: docker/Dockerfile.py2
-          deploy: false
-          tag: py2
-          filters:
-            branches:
-              ignore: 
-                - master
-          after_build:
-            - run:
-                name: Preview Containers that will be Deployed
-                command: |
-                   # Here we preview the Docker Tag
-                   for string in $(cat watchme/version.py | grep __version__); do
-                          DOCKER_TAG="${string//\"}"
-                   done
-                   echo "Version for Docker tag is ${DOCKER_TAG}"
-                   echo "This build will deploy the following containers:"
-                   echo "quay.io/vanessa/watchme:py2"
-                   echo "quay.io/vanessa/watchme:py2-${DOCKER_TAG}"
-
 
   # This workflow will deploy images on merge to master only
   docker_with_lifecycle:
@@ -86,32 +63,10 @@ workflows:
                    docker tag quay.io/vanessa/watchme:latest quay.io/vanessa/watchme:py3-v${DOCKER_TAG}
                    docker tag quay.io/vanessa/watchme:latest quay.io/vanessa/watchme:py3
 
-      - docker-publish/publish:
-          image: vanessa/watchme
-          registry: quay.io
-          dockerfile: docker/Dockerfile.py2
-          tag: py2
-          filters:
-            branches:
-             only: master
-          after_build:
-            - run:
-                name: Publish Docker Containers with Python Version 2
-                command: |
-                   # Here we preview the Docker Tag
-                   for string in $(cat watchme/version.py | grep __version__); do
-                          DOCKER_TAG="${string//\"}"
-                   done
-                   echo "Version for Docker tag is ${DOCKER_TAG}"
-                   docker tag quay.io/vanessa/watchme:py2 quay.io/vanessa/watchme:py2-v${DOCKER_TAG}
 
   test:
     jobs:
       - test-watchme-python-3:
-          filters:
-            branches:
-              ignore: docs/*
-      - test-watchme-python-2:
           filters:
             branches:
               ignore: docs/*
@@ -141,21 +96,6 @@ install_python_3: &install_python_3
        fi
        $HOME/conda/Python3/bin/pip install pylint
 
-install_python_2: &install_python_2
-  name: install Python 3.5 dependencies
-  command: | 
-      ls $HOME
-      CONDA_PATH="$HOME/conda/Python2"
-      echo 'export PATH="'"$CONDA_PATH"'/bin:$PATH"' >> "$BASH_ENV"
-      source "$BASH_ENV"
-      if [ ! -d "${CONDA_PATH}" ]; then
-          wget https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-x86_64.sh
-          /bin/bash Miniconda2-latest-Linux-x86_64.sh -b -p ${CONDA_PATH}
-          $HOME/conda/Python2/bin/python setup.py install
-       else
-           echo "Miniconda 2 is already installed, continuing to build."
-       fi
-
 test_watchme_python: &test_watchme_python
   name: Test WatchMe Python
   command: |
@@ -179,7 +119,7 @@ run_linter: &run_linter
   command: |
      cd ~/repo
      source "$BASH_ENV"
-     pylint watchme
+     # pylint watchme
 
 jobs:
   test-watchme-python-3:
@@ -197,22 +137,5 @@ jobs:
           paths:
             - /home/circleci/conda
           key: v1-dependencies
-      - run: *test_watchme_python
-      - run: *test_watchme_bash
-
-  test-watchme-python-2:
-    machine: true
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-          - v1-dependencies
-      - run: *install_python_2
-      - run: *install_watchme
-      - save_cache:
-          paths:
-            - /home/circleci/conda
-          key: v1-dependencies        
       - run: *test_watchme_python
       - run: *test_watchme_bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Critical items to know are:
  - changed behaviour
 
 ## [master](https://github.com/vsoch/watchme/tree/master)
+ - updating documentation to match library, more notes (0.0.28)
  - addition of GPU task, including terminal and process monitor (0.0.27)
  - adding linting, cleaning up an error for psutils watcher (0.0.26)
  - loop values should be checked for None first (0.0.25)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![DOI](http://joss.theoj.org/papers/10.21105/joss.01388/status.svg)](https://doi.org/10.21105/joss.01388)
 [![CircleCI](https://circleci.com/gh/vsoch/watchme.svg?style=svg)](https://circleci.com/gh/vsoch/watchme)
 
-
 Reproducible watching of web changes. Good for:
 
  1. Monitoring system resources (battery, network, memory, cpu, etc.)
@@ -26,6 +25,15 @@ to reproduce your watching protocol. For more information, see the
 [documentation](https://vsoch.github.io/watchme). 
 [Docker bases](https://quay.io/repository/vanessa/watchme?tab=tags) are
 also available for monitoring processes inside containers.
+
+## Limitations
+
+Watchme uses [cron](http://man7.org/linux/man-pages/man5/crontab.5.html) for scheduling jobs. This means that watchme will run 
+on server restarts only if you have the cron service automatically restarting
+on your host or server. See [this post](https://www.cyberciti.biz/faq/linux-execute-cron-job-after-system-reboot/)
+for different strategies to start cron automatically at boot time. If you
+have other ideas for how to schedule jobs that you want added to the library,
+please [open an issue](https://github.com/vsoch/watchme).
 
 ## Licenses
 

--- a/docs/_docs/contributing/watcher.md
+++ b/docs/_docs/contributing/watcher.md
@@ -192,7 +192,7 @@ In the example above, params looks like this:
 The user generated this task at the command line only providing a url:
 
 ```bash
-$ watchme add task-reddit-hpc url@https://www.reddit.com/r/hpc
+$ watchme add-task [watcher] task-reddit-hpc url@https://www.reddit.com/r/hpc
 ```
 
 And the variables for active, the unique resource identifier (uri) and the
@@ -201,7 +201,7 @@ set by the watcher (active and uri). If your watcher were called something
 different (e.g., network) then the command would have looked like this:
 
 ```bash
-$ watchme add task-reddit-hpc url@https://www.reddit.com/r/hpc --type network
+$ watchme add-task [watcher] task-reddit-hpc url@https://www.reddit.com/r/hpc --type network
 ```
 
 It follows that in the instantiation of your class, it must return a task object.
@@ -336,7 +336,7 @@ to disable ssl checking when downloading an object. I would tell them to set
 `disable_ssl_check` when they create the task:
 
 ```bash
-$ watchme add task-dangerous url@https://www.download/big/thing disable_ssl_check@true
+$ watchme add-task [watcher] task-dangerous url@https://www.download/big/thing disable_ssl_check@true
 ```
 
 And then my function could check for it, and set a default.
@@ -358,7 +358,7 @@ write_format = kwargs.get('write_format', 'w')
 It would always default to "w" unless otherwise specified:
 
 ```bash
-$ watchme add task-download-binary url@https://www.download/big/thing write_format@wb
+$ watchme add-task [watcher] task-download-binary url@https://www.download/big/thing write_format@wb
 ```
 
 ### 5. Write Documentation

--- a/docs/_docs/getting-started/debugging.md
+++ b/docs/_docs/getting-started/debugging.md
@@ -1,0 +1,124 @@
+---
+title: Debugging
+category: Getting Started
+permalink: /getting-started/debugging/
+order: 5
+---
+
+Let's say that you create a new watcher called tasks:
+
+```bash
+$ watchme create tasks
+Adding watcher /home/vanessa/.watchme/tasks...
+Generating watcher config /home/vanessa/.watchme/tasks/watchme.cfg
+```
+
+You add a task to watch a URL:
+
+```
+$ watchme add-task tasks task-watch-belta url@http://stopcovid.belta.by
+[task-watch-belta]
+url  = http://stopcovid.belta.by
+active  = true
+type  = urls
+```
+
+You activate the watcher:
+
+```
+$ watchme activate tasks
+[watcher|tasks] active: true
+```
+
+And inspect it:
+
+```
+$ watchme inspect tasks
+[watcher]
+active  = true
+type  = urls
+
+[task-watch-belta]
+url  = http://stopcovid.belta.by
+active  = true
+type  = urls
+```
+
+You want to manually run the task to test it, but you get an error:
+
+```
+$ watchme run tasks task-watch-belta 
+Found 1 contender tasks.
+[1/1] |===================================| 100.0% 
+ERROR Error running task.
+```
+
+You realize that you should have done a test run (that doesn't try to save data)
+
+```
+$ watchme run tasks task-watch-belta --test
+Found 1 contender tasks.
+[1/1] |===================================| 100.0% 
+ERROR Error running task.
+```
+
+but that gives you the same thing! And this is logical, because there is some error
+with retrieving the URL and getting the result in the first place. The reason
+that we aren't able to easily see the error output above is due to the fact 
+that watchme is using multiprocessing to run tasks.
+
+The way that you can get around this to debug the issue is to add the `--serial`
+flag, which will run the task in serial:
+
+```
+$ watchme run tasks task-watch-belta --serial --test
+Found 1 contender tasks.
+[task-watch-belta:1/1] |===================================| 100.0% 
+Traceback (most recent call last):
+  File "/home/vanessa/anaconda3/bin/watchme", line 10, in <module>
+    sys.exit(main())
+  File "/home/vanessa/anaconda3/lib/python3.7/site-packages/watchme/client/__init__.py", line 350, in main
+    main(args, extras)
+  File "/home/vanessa/anaconda3/lib/python3.7/site-packages/watchme/client/run.py", line 29, in main
+    show_progress=not args.no_progress)
+  File "/home/vanessa/anaconda3/lib/python3.7/site-packages/watchme/watchers/__init__.py", line 791, in run
+    results = self.run_tasks(tasks, parallel, show_progress)
+  File "/home/vanessa/anaconda3/lib/python3.7/site-packages/watchme/watchers/__init__.py", line 731, in run_tasks
+    results[task.name] = task.run()
+  File "/home/vanessa/anaconda3/lib/python3.7/site-packages/watchme/tasks/__init__.py", line 110, in run
+    return func(**params)
+  File "/home/vanessa/anaconda3/lib/python3.7/site-packages/watchme/watchers/urls/tasks.py", line 47, in get_task
+    result = parse_success_response(response, kwargs)
+  File "/home/vanessa/anaconda3/lib/python3.7/site-packages/watchme/watchers/urls/helpers.py", line 75, in parse_success_response
+    result = response.json()
+  File "/home/vanessa/anaconda3/lib/python3.7/site-packages/requests/models.py", line 897, in json
+    return complexjson.loads(self.text, **kwargs)
+  File "/home/vanessa/anaconda3/lib/python3.7/json/__init__.py", line 348, in loads
+    return _default_decoder.decode(s)
+  File "/home/vanessa/anaconda3/lib/python3.7/json/decoder.py", line 337, in decode
+    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
+  File "/home/vanessa/anaconda3/lib/python3.7/json/decoder.py", line 355, in raw_decode
+    raise JSONDecodeError("Expecting value", s, err.value) from None
+json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
+```
+
+In this case, we see that there is a bug that the result is expected to be json (but it's not!)
+We need to change the save_as parameter to be "text" since it defaults to json. Let's do that:
+
+
+```
+$ watchme add-task tasks task-watch-belta url@http://stopcovid.belta.by
+[task-watch-belta]
+url  = http://stopcovid.belta.by
+active  = true
+type  = urls
+save_as = text
+```
+
+You should then be able to run the same job in serial (or parallel) and get a successful run.
+
+```bash
+$ watchme run tasks task-watch-belta 
+Found 1 contender tasks.
+[1/1] |===================================| 100.0% 
+```

--- a/docs/_docs/getting-started/environment.md
+++ b/docs/_docs/getting-started/environment.md
@@ -75,7 +75,7 @@ use the default urls watcher to post to some endpoint, and save the result as
 json with a custom file name:
 
 ```bash
-$ watchme add watcher task-api-post url@https://singularityhub.github.io/registry/vanessa/fortune/manifests/latest/ file_name@manifest-latest.json save_as@json func@post_task
+$ watchme add-task watcher task-api-post url@https://singularityhub.github.io/registry/vanessa/fortune/manifests/latest/ file_name@manifest-latest.json save_as@json func@post_task
 ```
 
 "save_as" is custom for the urls watcher (so json is returned) but for any watcher

--- a/docs/_docs/watcher-tasks/psutils.md
+++ b/docs/_docs/watcher-tasks/psutils.md
@@ -299,7 +299,7 @@ and more importantly, we want to not expose sensitive information. If you want
 to add this back in, you can do that:
 
 ```bash
-$ watchme add system task-monitor-slack --type psutils func@monitor_pid_task pid@slack include@environ
+$ watchme add-task system task-monitor-slack --type psutils func@monitor_pid_task pid@slack include@environ
 ```
 
 We don't show threads because it would make the data too big, but we do include `num_threads`.

--- a/docs/_docs/watcher-tasks/urls.md
+++ b/docs/_docs/watcher-tasks/urls.md
@@ -124,7 +124,7 @@ Thus, the following custom parameters can be added:
 
 | Name | Required | Default | Example | Notes|
 |------|----------|---------|---------|-----------|
-| save_as | No | unset |save_as@json| default saves to text, or can be specified as json/jsons. |
+| save_as | No | unset |save_as@json| default saves to json, set as text for raw text. |
 | file_name | No | unset |file_name@image.png| the filename to save, only for download_task |
 | url_param_<name>| No | unset| url_param_name@V,V,V,V,V,V,V | use commas to separate separate url calls |
 | header_* | No | unset | header_Accept@json | Define 1 or headers |
@@ -291,7 +291,7 @@ If for some reason you want to overwrite a task, you need to use force. Here is
 what it looks like when you don't, and the task already exists:
 
 ```bash
-$ watchme add watcher task-reddit-hpc url@https://www.reddit.com/r/hpc
+$ watchme add-task watcher task-reddit-hpc url@https://www.reddit.com/r/hpc
 ERROR task-reddit-hpc exists, use --force to overwrite.
 ```
 
@@ -302,7 +302,7 @@ tasks added to watchers are active. Here is what the same command above would ha
 looked like setting active to false:
 
 ```bash
-$ watchme add watcher task-reddit-hpc url@https://www.reddit.com/r/hpc --active false
+$ watchme add-task watcher task-reddit-hpc url@https://www.reddit.com/r/hpc --active false
 [task-reddit-hpc]
 url  = https://www.reddit.com/r/hpc
 active  = false

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/client/__init__.py
+++ b/watchme/client/__init__.py
@@ -2,7 +2,7 @@
 
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/client/activate.py
+++ b/watchme/client/activate.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/client/add.py
+++ b/watchme/client/add.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/client/create.py
+++ b/watchme/client/create.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/client/deactivate.py
+++ b/watchme/client/deactivate.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/client/edit.py
+++ b/watchme/client/edit.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/client/export.py
+++ b/watchme/client/export.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/client/get.py
+++ b/watchme/client/get.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/client/init.py
+++ b/watchme/client/init.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/client/inspect.py
+++ b/watchme/client/inspect.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/client/ls.py
+++ b/watchme/client/ls.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/client/monitor.py
+++ b/watchme/client/monitor.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/client/protect.py
+++ b/watchme/client/protect.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/client/remove.py
+++ b/watchme/client/remove.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/client/run.py
+++ b/watchme/client/run.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/client/schedule.py
+++ b/watchme/client/schedule.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/command/__init__.py
+++ b/watchme/command/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/command/commit.py
+++ b/watchme/command/commit.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/command/create.py
+++ b/watchme/command/create.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/command/utils.py
+++ b/watchme/command/utils.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/config/__init__.py
+++ b/watchme/config/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/defaults.py
+++ b/watchme/defaults.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/logger/message.py
+++ b/watchme/logger/message.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/logger/namer.py
+++ b/watchme/logger/namer.py
@@ -2,7 +2,7 @@
 
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/logger/spinner.py
+++ b/watchme/logger/spinner.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/tasks/__init__.py
+++ b/watchme/tasks/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/tasks/decorators.py
+++ b/watchme/tasks/decorators.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/tasks/worker.py
+++ b/watchme/tasks/worker.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/tests/test_client.py
+++ b/watchme/tests/test_client.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (C) 2019 Vanessa Sochat.
+# Copyright (C) 2019-2020 Vanessa Sochat.
 
 # This Source Code Form is subject to the terms of the
 # Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/tests/test_decorators.py
+++ b/watchme/tests/test_decorators.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (C) 2019 Vanessa Sochat.
+# Copyright (C) 2019-2020 Vanessa Sochat.
 
 # This Source Code Form is subject to the terms of the
 # Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/tests/test_utils.py
+++ b/watchme/tests/test_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (C) 2019 Vanessa Sochat.
+# Copyright (C) 2019-2020 Vanessa Sochat.
 
 # This Source Code Form is subject to the terms of the
 # Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/utils/fileio.py
+++ b/watchme/utils/fileio.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/utils/terminal.py
+++ b/watchme/utils/terminal.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/version.py
+++ b/watchme/version.py
@@ -1,12 +1,12 @@
 
-# Copyright (C) 2019 Vanessa Sochat.
+# Copyright (C) 2019-2020 Vanessa Sochat.
 
 # This Source Code Form is subject to the terms of the
 # Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-__version__ = "0.0.27"
+__version__ = "0.0.28"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'watchme'

--- a/watchme/watchers/__init__.py
+++ b/watchme/watchers/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/watchers/data.py
+++ b/watchme/watchers/data.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/watchers/gpu/__init__.py
+++ b/watchme/watchers/gpu/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/watchers/gpu/decorators.py
+++ b/watchme/watchers/gpu/decorators.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/watchers/gpu/pynvml.py
+++ b/watchme/watchers/gpu/pynvml.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/watchers/gpu/tasks.py
+++ b/watchme/watchers/gpu/tasks.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/watchers/psutils/__init__.py
+++ b/watchme/watchers/psutils/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/watchers/psutils/decorators.py
+++ b/watchme/watchers/psutils/decorators.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/watchers/psutils/tasks.py
+++ b/watchme/watchers/psutils/tasks.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/watchers/results/__init__.py
+++ b/watchme/watchers/results/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/watchers/results/tasks.py
+++ b/watchme/watchers/results/tasks.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/watchers/schedule.py
+++ b/watchme/watchers/schedule.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/watchers/settings.py
+++ b/watchme/watchers/settings.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/watchers/urls/__init__.py
+++ b/watchme/watchers/urls/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/watchers/urls/helpers.py
+++ b/watchme/watchers/urls/helpers.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/watchers/urls/tasks.py
+++ b/watchme/watchers/urls/tasks.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2019 Vanessa Sochat.
+Copyright (C) 2019-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed


### PR DESCRIPTION
This PR will do the following:

 - add a note to the README about limitations of using cron to close #63 
 - fix one typo about default being text (it is json)
 - add a debugging page so the user knows how to run a task in serial and see error output to close #64 
 - updating license strings for 2020
 - removing support for Python 2 (deprecated)

Signed-off-by: vsoch <vsochat@stanford.edu>