### PR TITLE
fixing typo in docs, updating headers and black formatting

### DIFF
--- a/docs/_docs/getting-started/config.md
+++ b/docs/_docs/getting-started/config.md
@@ -81,5 +81,4 @@ the above is from the urls watcher type, since it will watch web pages for chang
 
 ## Licenses
 
-This code is licensed under the Affero GPL, version 3.0 or later [LICENSE](LICENSE).
-The SIF Header format is licesed by [Sylabs](https://github.com/sylabs/sif/blob/master/pkg/sif/sif.go).
+This code is licensed under the Mozilla, version 2.0 or later [LICENSE](LICENSE).

--- a/docs/_docs/getting-started/index.md
+++ b/docs/_docs/getting-started/index.md
@@ -182,13 +182,15 @@ $ watchme add-task watcher task-singularity-release url@https://github.com/sylab
 url  = https://github.com/sylabs/singularity/releases
 active  = true
 type  = urls
+save_as = text
 ```
 
 In the example above, we added a task called "task-singularity-release" to the default
 watcher "watcher." The only required variable is the url, and we provided it
 in the format `<key>@<value>`. This is how you will add any parameter to a task,
-and the parameters allowed will vary based on the task type. In the above, we didn't
-define a `--type` variable. By default, the setting is `--type url`. After
+and the parameters allowed will vary based on the task type. We also specified that the page
+we are going to retrieve is `save_as` text, meaning that it's not json (default).
+In the above, we didn't define a `--type` variable. By default, the setting is `--type url`. After
 you add a task, you can quickly verify it was added by looking at the configuration file
 directly:
 
@@ -203,6 +205,7 @@ active = false
 url = https://github.com/sylabs/singularity/releases
 active = true
 type = urls
+save_as = text
 ```
 
 While you don't need to manually edit this file, there isn't any reason that you can't if you wanted to. 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 """
 
-Copyright (C) 2019-2020 Vanessa Sochat.
+Copyright (C) 2019-2021 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/watchme/__init__.py
+++ b/watchme/__init__.py
@@ -1,30 +1,23 @@
-"""
-
-Copyright (C) 2019 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.version import __version__
 
 
 def get_watcher(name="watcher", base=None, create=False, quiet=True, **kwargs):
     """
-       get the correct watcher depending on the environment variable
-       WATCHME_WATCHER or default to "watcher"
+    get the correct watcher depending on the environment variable
+    WATCHME_WATCHER or default to "watcher"
 
-       Parameters
-       ==========
-       name: the name of the watcher, will be made all lowercase
-       base: the watcher base, if not defined, will use WATCHER_BASE_DIR envar
-       create: if the watcher folder doesn't exist, create it (default False)
-               for all interactions with a watcher other than create, we should
-               exit if the watcher the user wants doesn't exist.
-       quiet: if True, suppress most output about the client (e.g. speak)
+    Parameters
+    ==========
+    name: the name of the watcher, will be made all lowercase
+    base: the watcher base, if not defined, will use WATCHER_BASE_DIR envar
+    create: if the watcher folder doesn't exist, create it (default False)
+            for all interactions with a watcher other than create, we should
+            exit if the watcher the user wants doesn't exist.
+    quiet: if True, suppress most output about the client (e.g. speak)
     """
     from watchme.watchers import Watcher
 

--- a/watchme/client/__init__.py
+++ b/watchme/client/__init__.py
@@ -1,14 +1,8 @@
 #!/usr/bin/env python
 
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.logger import bot
 from watchme.defaults import WATCHME_WATCHER, WATCHME_TASK_TYPES, WATCHME_DEFAULT_TYPE
@@ -362,16 +356,15 @@ def get_parser():
 
 
 def main():
-    """the main entry point for the WatchMe Command line application.
-    """
+    """the main entry point for the WatchMe Command line application."""
 
     # Customize parser
 
     parser = get_parser()
 
     def help(return_code=0):
-        """print help, including the software version and active client 
-           and exit with return code.
+        """print help, including the software version and active client
+        and exit with return code.
         """
 
         version = watchme.__version__

--- a/watchme/client/activate.py
+++ b/watchme/client/activate.py
@@ -1,19 +1,12 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme import get_watcher
 
 
 def main(args, extra):
-    """activate one or more watchers
-    """
+    """activate one or more watchers"""
     # Doesn't work if watcher not provided
     watcher = args.watcher[0]
     watcher = get_watcher(watcher, base=args.base)

--- a/watchme/client/add.py
+++ b/watchme/client/add.py
@@ -1,20 +1,13 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme import get_watcher
 from watchme.logger import bot
 
 
 def main(args, extra):
-    """add a task for a watcher
-    """
+    """add a task for a watcher"""
     # Required - will print help if not provided
     name = args.watcher[0]
     task = args.task[0]

--- a/watchme/client/create.py
+++ b/watchme/client/create.py
@@ -12,8 +12,7 @@ from watchme.command import create_watcher
 
 
 def main(args, extra):
-    """create means creating one or more watchers.
-    """
+    """create means creating one or more watchers."""
 
     watchers = args.watchers
     if len(watchers) == 0:

--- a/watchme/client/deactivate.py
+++ b/watchme/client/deactivate.py
@@ -1,19 +1,12 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme import get_watcher
 
 
 def main(args, extra):
-    """deactivate one or more watchers
-    """
+    """deactivate one or more watchers"""
     # Doesn't work if watcher not provided
     watcher = args.watcher[0]
     watcher = get_watcher(watcher, base=args.base)

--- a/watchme/client/edit.py
+++ b/watchme/client/edit.py
@@ -1,20 +1,13 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme import get_watcher
 from watchme.logger import bot
 
 
 def main(args, extra):
-    """edit the configuration for a watcher task
-    """
+    """edit the configuration for a watcher task"""
     # Required - will print help if not provided
     name = args.watcher[0]
     action = args.action[0]

--- a/watchme/client/export.py
+++ b/watchme/client/export.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme import get_watcher
 from watchme.utils import write_json
@@ -16,8 +10,7 @@ import os
 
 
 def main(args, extra):
-    """export temporal data for a watcher
-    """
+    """export temporal data for a watcher"""
     # Required - will print help if not provided
     name = args.watcher[0]
     task = args.task[0]

--- a/watchme/client/get.py
+++ b/watchme/client/get.py
@@ -1,19 +1,13 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.command import git_clone
 
 
 def main(args, extra):
     """get a watcher using git, meaning clone to a temporary location and then
-       copying the entire repo (or a subfolder) to the watcher base.
+    copying the entire repo (or a subfolder) to the watcher base.
     """
 
     # Required - will print help if not provided

--- a/watchme/client/init.py
+++ b/watchme/client/init.py
@@ -1,19 +1,12 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.command.create import create_watcher_base, create_watcher
 
 
 def main(args, extra):
-    """init means creating the watcher base, and the first (default) watcher.
-    """
+    """init means creating the watcher base, and the first (default) watcher."""
 
     # Create the base
     create_watcher_base(args.watcher, args.base)

--- a/watchme/client/inspect.py
+++ b/watchme/client/inspect.py
@@ -1,19 +1,12 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme import get_watcher
 
 
 def main(args, extra):
-    """activate one or more watchers
-    """
+    """activate one or more watchers"""
     # Required - will print help if not provided
     name = args.watcher[0]
     watcher = get_watcher(name, base=args.base, create=False)

--- a/watchme/client/ls.py
+++ b/watchme/client/ls.py
@@ -1,20 +1,13 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.command import get_watchers, list_task, list_watcher, list_watcher_types
 from watchme.logger import bot
 
 
 def main(args, extra):
-    """list installed watchers
-    """
+    """list installed watchers"""
     if args.watchers is True:
         list_watcher_types()
 

--- a/watchme/client/monitor.py
+++ b/watchme/client/monitor.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.command import get_watchers
 from watchme import get_watcher
@@ -16,8 +10,8 @@ import json
 
 def main(args, extra):
     """monitor a task (from the command line), meaning wrapping it with
-       multiprocessing, getting the id, and returning a result (command line 
-       or written to file)
+    multiprocessing, getting the id, and returning a result (command line
+    or written to file)
     """
     # The first argument will either be part of a command, or a watcher
     watcher = args.watcher

--- a/watchme/client/protect.py
+++ b/watchme/client/protect.py
@@ -1,19 +1,12 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme import get_watcher
 
 
 def main(args, extra):
-    """protect or freeze a watcher, or disable.
-    """
+    """protect or freeze a watcher, or disable."""
     # Required - will print help if not provided
     name = args.watcher[0]
     watcher = get_watcher(name, base=args.base, create=False)

--- a/watchme/client/remove.py
+++ b/watchme/client/remove.py
@@ -1,20 +1,13 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme import get_watcher
 from watchme.logger import bot
 
 
 def main(args, extra):
-    """activate one or more watchers
-    """
+    """activate one or more watchers"""
     # Required - will print help if not provided
     name = args.watcher[0]
     watcher = get_watcher(name, base=args.base, create=False)

--- a/watchme/client/run.py
+++ b/watchme/client/run.py
@@ -1,19 +1,13 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme import get_watcher
 
 
 def main(args, extra):
     """run a watcher, optionally supplying one or more regular expressions to
-       check for.
+    check for.
     """
     # Required - will print help if not provided
     name = args.watcher[0]

--- a/watchme/client/schedule.py
+++ b/watchme/client/schedule.py
@@ -1,20 +1,13 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme import get_watcher
 from watchme.logger import bot
 
 
 def main(args, extra):
-    """activate one or more watchers
-    """
+    """activate one or more watchers"""
     # Required - will print help if not provided
     name = args.watcher[0]
 

--- a/watchme/command/commit.py
+++ b/watchme/command/commit.py
@@ -18,8 +18,8 @@ import time
 
 def git_pwd(func):
     """ensure that we are in the repo present working directory before running
-       a git command. Return to where we were before after completion.
-       The repo is always the first (positional or keyword) argument.
+    a git command. Return to where we were before after completion.
+    The repo is always the first (positional or keyword) argument.
     """
 
     def git_pwd_inner(*args, **kwargs):
@@ -49,11 +49,11 @@ def git_pwd(func):
 def git_commit(repo, task, message):
     """Commit to the git repo with a particular message. folder.
 
-       Parameters
-       ==========
-       repo: the repository to commit to.
-       task: the name of the task to add to the commit message
-       message: the message for the commit, passed from the client
+    Parameters
+    ==========
+    repo: the repository to commit to.
+    task: the name of the task to add to the commit message
+    message: the message for the commit, passed from the client
     """
     # Commit with the watch group and date string
     message = "watchme %s %s" % (task, message)
@@ -67,13 +67,13 @@ def git_commit(repo, task, message):
 @git_pwd
 def write_timestamp(repo, task, filename="TIMESTAMP"):
     """write a file that includes the last run timestamp. This should be written
-       in each task folder after a run.
+    in each task folder after a run.
 
-       Parameters
-       ==========
-       repo: the repository to write the TIMESTAMP file to
-       task: the name of the task folder to write the file to
-       filename: the filename (defaults to TIMESTAMP)
+    Parameters
+    ==========
+    repo: the repository to write the TIMESTAMP file to
+    task: the name of the task folder to write the file to
+    filename: the filename (defaults to TIMESTAMP)
     """
     ts = time.time()
     strtime = datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
@@ -85,11 +85,11 @@ def write_timestamp(repo, task, filename="TIMESTAMP"):
 @git_pwd
 def git_date(repo, commit):
     """get the date for a particular commit.
-    
-       Parameters
-       ==========
-       repo: the full path to the repository
-       commit: the commit to get the date for
+
+    Parameters
+    ==========
+    repo: the full path to the repository
+    commit: the commit to get the date for
     """
     command = "git show -s --format=" + "%ci " + commit
     bot.debug(command)
@@ -101,14 +101,14 @@ def git_date(repo, commit):
 @git_pwd
 def git_show(repo, commit, filename):
     """git show is used to pipe the content of a file at a particular commit
-       to the screen (and calling python client). We must be in the $PWD of the
-       repo for this to work.
+    to the screen (and calling python client). We must be in the $PWD of the
+    repo for this to work.
 
-       Parameters
-       ==========
-       repo: the repository to interact with
-       commit: the commit to investigate for the file
-       filename: the relative path to the file
+    Parameters
+    ==========
+    repo: the repository to interact with
+    commit: the commit to investigate for the file
+    filename: the relative path to the file
     """
     command = "git show %s:%s" % (commit, filename)
     bot.debug(command)
@@ -119,23 +119,23 @@ def git_show(repo, commit, filename):
 
 def git_clone(repo, name=None, base=None, force=False):
     """clone a git repo to a destination. The user can provide the following
-       groupings of arguments:
+    groupings of arguments:
 
-       base without name: destination is ignored, the repo is cloned (named as
-       it is) to the base. If the folder exists, --force must be used to remove
-       it first.
+    base without name: destination is ignored, the repo is cloned (named as
+    it is) to the base. If the folder exists, --force must be used to remove
+    it first.
 
-       base with name: destination is ignored, repo is cloned (and named based
-       on name variable) to the base. The same applies for force.
+    base with name: destination is ignored, repo is cloned (and named based
+    on name variable) to the base. The same applies for force.
 
-       dest provided: the repo is cloned to the destination, if it doesn't exist
-       and/or force is True.
+    dest provided: the repo is cloned to the destination, if it doesn't exist
+    and/or force is True.
 
-       Parameters
-       ==========
-       name: the name of the watcher to add
-       base: the base of the watcher (defaults to $HOME/.watchme
-       force: remove first if already exists
+    Parameters
+    ==========
+    name: the name of the watcher to add
+    base: the base of the watcher (defaults to $HOME/.watchme
+    force: remove first if already exists
     """
     if base is None:
         base = WATCHME_BASE_DIR
@@ -177,15 +177,15 @@ def git_clone(repo, name=None, base=None, force=False):
 @git_pwd
 def get_commits(repo, from_commit=None, to_commit=None, grep=None, filename=None):
     """get commits, starting from and going to a particular commit. if grep
-       is defined, filter commits to those with messages that match that
-       particular expression
+    is defined, filter commits to those with messages that match that
+    particular expression
 
-       Parameters
-       ==========
-       from_commit: the commit to start at
-       to_commit: the commit to go to
-       grep: the expression to match (not used if None)
-       filename: the filename to filter to. Includes all files if not specified.
+    Parameters
+    ==========
+    from_commit: the commit to start at
+    to_commit: the commit to go to
+    grep: the expression to match (not used if None)
+    filename: the filename to filter to. Includes all files if not specified.
     """
     command = 'git log --all --oneline --pretty=tformat:"%H"'
 
@@ -215,11 +215,11 @@ def get_commits(repo, from_commit=None, to_commit=None, grep=None, filename=None
 
 def get_earliest_commit():
     """get the earliest commit for a repository. This is intended to be used
-       when in the present working directory
+    when in the present working directory
 
-       Parameters
-       ==========
-       repo: the repository path to get the commit from
+    Parameters
+    ==========
+    repo: the repository path to get the commit from
     """
     commit = run_command("git rev-list --max-parents=0 HEAD")["message"]
     return commit.strip("\n")
@@ -228,9 +228,9 @@ def get_earliest_commit():
 def get_latest_commit():
     """get the latest commit for a repository in the present working directory
 
-       Parameters
-       ==========
-       repo: the repository path to get the commit from
+    Parameters
+    ==========
+    repo: the repository path to get the commit from
     """
     commit = run_command('git log -n 1 --pretty=format:"%H"')["message"]
     return commit.strip("\n")
@@ -240,10 +240,10 @@ def get_latest_commit():
 def git_add(repo, files):
     """add one or more files to the git repo.
 
-       Parameters
-       ==========
-       repo: the repository to commit to.
-       files: one or more files to add.
+    Parameters
+    ==========
+    repo: the repository to commit to.
+    files: one or more files to add.
     """
     if not isinstance(files, list):
         files = [files]

--- a/watchme/command/create.py
+++ b/watchme/command/create.py
@@ -17,14 +17,14 @@ import os
 
 def create_watcher(name=None, watcher_type=None, base=None):
     """create a watcher, meaning a folder with a configuration and
-       initialized git repo.
+    initialized git repo.
 
-       Parameters
-       ==========
-       name: the watcher to create, uses default or WATCHME_WATCHER
-       watcher_type: the type of watcher to create. defaults to 
-                     WATCHER_DEFAULT_TYPE
-        base: The watcher base to use (defaults to $HOME/.watchme)
+    Parameters
+    ==========
+    name: the watcher to create, uses default or WATCHME_WATCHER
+    watcher_type: the type of watcher to create. defaults to
+                  WATCHER_DEFAULT_TYPE
+     base: The watcher base to use (defaults to $HOME/.watchme)
     """
     if name is None:
         name = WATCHME_WATCHER
@@ -56,10 +56,10 @@ def create_watcher(name=None, watcher_type=None, base=None):
 def create_watcher_base(name=None, base=None):
     """create a watch base and default repo, if it doesn't already exist.
 
-       Parameters
-       ==========
-       name: the watcher to create, uses default or WATCHME_WATCHER
-       base: the watcher base, defaults to WATCHME_BASE_DIR
+    Parameters
+    ==========
+    name: the watcher to create, uses default or WATCHME_WATCHER
+    base: the watcher base, defaults to WATCHME_BASE_DIR
     """
     if base is None:
         base = WATCHME_BASE_DIR

--- a/watchme/command/utils.py
+++ b/watchme/command/utils.py
@@ -20,11 +20,11 @@ import shutil
 
 def get_watchers(base=None, quiet=False):
     """list the watchers installed at a base. If base is not defined,
-       the default base is used.
+    the default base is used.
 
-       Parameters
-       ==========
-       base: the watchme base, defaults to $HOME/.watchme
+    Parameters
+    ==========
+    base: the watchme base, defaults to $HOME/.watchme
     """
     if base is None:
         base = WATCHME_BASE_DIR
@@ -41,9 +41,9 @@ def get_watchers(base=None, quiet=False):
 def list_watcher(watcher, base=None):
     """list the contents (tasks) of a single watcher.
 
-       Parameters
-       ==========
-       base: the watchme base, defaults to $HOME/.watchme
+    Parameters
+    ==========
+    base: the watchme base, defaults to $HOME/.watchme
     """
     if base is None:
         base = WATCHME_BASE_DIR
@@ -55,11 +55,11 @@ def list_watcher(watcher, base=None):
 def list_task(watcher, task, base=None):
     """list the contents (result files) of a task folder beloning to a watcher.
 
-       Parameters
-       ==========
-       watcher: the watcher folder to use
-       task: the task folder within
-       base: the watchme base, defaults to $HOME/.watchme
+    Parameters
+    ==========
+    watcher: the watcher folder to use
+    task: the task folder within
+    base: the watchme base, defaults to $HOME/.watchme
     """
     if base is None:
         base = WATCHME_BASE_DIR
@@ -71,11 +71,11 @@ def list_task(watcher, task, base=None):
 def _general_list(path, prefix="path", base=None):
     """a shared function for listing (and returning) files.
 
-       Parameters
-       ==========
-       path: the full path to list, if it exists
-       prefix: a prefix to print for the type
-       base: the watchme base, defaults to $HOME/.watchme
+    Parameters
+    ==========
+    path: the full path to list, if it exists
+    prefix: a prefix to print for the type
+    base: the watchme base, defaults to $HOME/.watchme
     """
     if base is None:
         base = WATCHME_BASE_DIR
@@ -89,24 +89,23 @@ def _general_list(path, prefix="path", base=None):
 
 
 def list_watcher_types():
-    """list the exporter options provided by watchme
-    """
+    """list the exporter options provided by watchme"""
     bot.custom(prefix="watchme:", message="watcher task types", color="CYAN")
     bot.info("\n  ".join(WATCHME_TASK_TYPES))
 
 
 def clone_watcher(repo, base=None, name=None):
     """clone a watcher from Github (or other version control with git)
-       meaning that we clone to a temporary folder, and then move
-       to a new folder. By default, the user gets all tasks associated
-       with the watcher, along with the git folder so that removing
-       is also done with version control.
+    meaning that we clone to a temporary folder, and then move
+    to a new folder. By default, the user gets all tasks associated
+    with the watcher, along with the git folder so that removing
+    is also done with version control.
 
-       Parameters
-       ==========
-       repo: the repository to clone
-       base: the watchme base, defaults to $HOME/.watchme
-       name: a new name for the watcher, if a rename is desired.
+    Parameters
+    ==========
+    repo: the repository to clone
+    base: the watchme base, defaults to $HOME/.watchme
+    name: a new name for the watcher, if a rename is desired.
     """
     if base is None:
         base = WATCHME_BASE_DIR

--- a/watchme/config/__init__.py
+++ b/watchme/config/__init__.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.logger import bot
 from watchme.defaults import WATCHME_WATCHER, WATCHME_BASE_DIR, WATCHME_DEFAULT_TYPE
@@ -21,14 +15,12 @@ import os
 
 
 def get_configfile_template():
-    """return the full path to the default configuration file
-    """
+    """return the full path to the default configuration file"""
     return _get_config("watchme.cfg")
 
 
 def _get_config(name):
-    """shared function to return a file in the config directory
-    """
+    """shared function to return a file in the config directory"""
     return os.path.abspath(os.path.join(get_installdir(), "config", name))
 
 
@@ -36,8 +28,7 @@ def _get_config(name):
 
 
 def get_configfile(name, base=None):
-    """return the full path to a specific watcher configuration
-    """
+    """return the full path to a specific watcher configuration"""
     if base is None:
         base = WATCHME_BASE_DIR
 
@@ -50,16 +41,14 @@ def get_configfile(name, base=None):
 
 
 def write_config(filename, config, mode="w"):
-    """use configparser to write a config object to filename
-    """
+    """use configparser to write a config object to filename"""
     with open(filename, mode) as filey:
         config.write(filey)
     return filename
 
 
 def read_config(filename):
-    """use configparser to write a config object to filename
-    """
+    """use configparser to write a config object to filename"""
     check_exists(filename)
     config = configparser.ConfigParser()
     config.read(filename)
@@ -71,11 +60,11 @@ def read_config(filename):
 
 def generate_watcher_config(path, watcher_type=None):
     """generate a watcher config, meaning a watcher folder in the watchme
-       base folder.
+    base folder.
 
-       Parameters
-       ==========
-       path: the path to the watcher repository
+    Parameters
+    ==========
+    path: the path to the watcher repository
     """
     check_exists(path)
     configfile = get_configfile_template()
@@ -102,7 +91,6 @@ def generate_watcher_config(path, watcher_type=None):
 
 
 def check_exists(filename):
-    """a general helper function to check for existence, and exit if not found.
-    """
+    """a general helper function to check for existence, and exit if not found."""
     if not os.path.exists(filename):
         bot.exit("Cannot find %s" % filename)

--- a/watchme/defaults.py
+++ b/watchme/defaults.py
@@ -1,16 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-The watcher is actually a connection to crontab. This is what helps to schedule
-the watched to check for changes at some frequency, and update the files.
-
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.logger import bot
 from watchme.utils import get_userhome
@@ -24,14 +14,14 @@ import sys
 
 
 def getenv(variable_key, default=None, required=False, silent=True):
-    """ attempt to get an environment variable. If the variable
-        is not found, None is returned.
+    """attempt to get an environment variable. If the variable
+    is not found, None is returned.
 
-        Parameters
-        ==========
-        variable_key: the variable name
-        required: exit with error if not found
-        silent: Do not print debugging information for variable
+    Parameters
+    ==========
+    variable_key: the variable name
+    required: exit with error if not found
+    silent: Do not print debugging information for variable
     """
     variable = os.environ.get(variable_key, default)
     if variable is None and required:

--- a/watchme/logger/message.py
+++ b/watchme/logger/message.py
@@ -1,15 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-The watcher is actually a connection to crontab. This is what helps to schedule
-the watched to check for changes at some frequency, and update the files.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 import os
 import sys
@@ -107,8 +98,7 @@ class WatchMeMessage:
         return False
 
     def isEnabledFor(self, messageLevel):
-        """check if a messageLevel is enabled to emit a level
-        """
+        """check if a messageLevel is enabled to emit a level"""
         if messageLevel <= self.level:
             return True
         return False
@@ -259,8 +249,7 @@ class WatchMeMessage:
         self.emit(DEBUG, message, "DEBUG")
 
     def is_quiet(self):
-        """is_quiet returns true if the level is under 1
-        """
+        """is_quiet returns true if the level is under 1"""
         if self.level < 1:
             return False
         return True
@@ -268,7 +257,7 @@ class WatchMeMessage:
     # Terminal ------------------------------------------
 
     def table(self, rows, col_width=2):
-        """table will print a table of entries. If the rows is 
+        """table will print a table of entries. If the rows is
         a dictionary, the keys are interpreted as column names. if
         not, a numbered list is used.
         """

--- a/watchme/logger/namer.py
+++ b/watchme/logger/namer.py
@@ -1,15 +1,8 @@
 #!/usr/bin/env python
 
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from random import choice
 
@@ -205,11 +198,11 @@ class RobotNamer:
         return delim.join([descriptor, noun, numbers])
 
     def _select(self, select_from):
-        """ select an element from a list using random.choice
-        
-            Parameters
-            ==========
-            should be a list of things to select from
+        """select an element from a list using random.choice
+
+        Parameters
+        ==========
+        should be a list of things to select from
         """
         if len(select_from) <= 0:
             return ""

--- a/watchme/logger/spinner.py
+++ b/watchme/logger/spinner.py
@@ -1,16 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-The watcher is actually a connection to crontab. This is what helps to schedule
-the watched to check for changes at some frequency, and update the files.
-
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 import sys
 import time

--- a/watchme/tasks/__init__.py
+++ b/watchme/tasks/__init__.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.logger import bot
 from watchme.utils import write_file, write_json
@@ -34,8 +28,7 @@ class TaskBase(object):
         self.validate()
 
     def get_type(self):
-        """get the watcher type.
-        """
+        """get the watcher type."""
         return self.type
 
     # Identification
@@ -51,9 +44,9 @@ class TaskBase(object):
     def set_params(self, params):
         """iterate through parameters, set into dictionary.
 
-           Parameters
-           ==========
-           params: a list of key@value pairs to set.
+        Parameters
+        ==========
+        params: a list of key@value pairs to set.
         """
         for key, value in params.items():
             key = key.lower()
@@ -61,7 +54,7 @@ class TaskBase(object):
 
     def export_params(self, active="true"):
         """export parameters, meaning returning a dictionary of the task
-           parameters plus the addition of the task type and active status.
+        parameters plus the addition of the task type and active status.
         """
         params = self.params.copy()
         params["active"] = active
@@ -72,8 +65,8 @@ class TaskBase(object):
 
     def validate(self):
         """validate the parameters set for the Task. Exit if there are any
-           errors. Ensure required parameters are defined, and have correct
-           values.
+        errors. Ensure required parameters are defined, and have correct
+        values.
         """
         self.valid = True
 
@@ -86,15 +79,14 @@ class TaskBase(object):
         self._validate()
 
     def _validate(self):
-        """validation function intended to be implemented by subclass.
-        """
+        """validation function intended to be implemented by subclass."""
         return
 
     # Run Single Task
 
     def run(self):
         """run an isolated task, meaning no update or communication with
-           the watcher. This will return the raw result.
+        the watcher. This will return the raw result.
         """
         params = self.export_params()
         func = self.export_func()
@@ -106,13 +98,13 @@ class TaskBase(object):
 
     def write_results(self, result, repo):
         """an entrypoint function for a general task. By default, we parse
-           results based on the result type. Any particular subclass of the
-           TaskBase can modify or extend these functions.
+        results based on the result type. Any particular subclass of the
+        TaskBase can modify or extend these functions.
 
-           Parameters
-           ==========
-           result: the result object to parse
-           repo: the repo base (watcher.repo)
+        Parameters
+        ==========
+        result: the result object to parse
+        repo: the repo base (watcher.repo)
         """
         files = []
 
@@ -176,13 +168,13 @@ class TaskBase(object):
 
     def _save_str_result(self, files, result, repo):
         """a helper function to return a list of files with added string
-           results. We do this twice in the saving function.
+        results. We do this twice in the saving function.
 
-           Parameters
-           ==========
-           files: the list of files to save (returned at the end)
-           result: the result object to parse, should be string
-           repo: the repo to write it to.
+        Parameters
+        ==========
+        files: the list of files to save (returned at the end)
+        result: the result object to parse, should be string
+        repo: the repo to write it to.
         """
         # if it's a path to a file, just save to repository
         if os.path.exists(result):
@@ -196,15 +188,15 @@ class TaskBase(object):
 
     def _save_list(self, results, repo, func, file_name):
         """general function to perform saving a list of content to json,
-           text, or moving paths. Used by save_file_list, save_json_list,
-           and save_text_list.
+        text, or moving paths. Used by save_file_list, save_json_list,
+        and save_text_list.
 
-           Parameters
-           ==========
-           results: list of results, assumed to be the correct type
-           repo: the repository base with the task folder
-           func: the function to call.
-           file_name: the base file name to use.
+        Parameters
+        ==========
+        results: list of results, assumed to be the correct type
+        repo: the repository base with the task folder
+        func: the function to call.
+        file_name: the base file name to use.
         """
         file_name, ext = os.path.splitext(file_name)
         files = []
@@ -218,11 +210,11 @@ class TaskBase(object):
 
     def _save_text(self, result, repo, file_name=None):
         """save a general text object to file.
- 
-           Parameters
-           ==========
-           result: the result object to save, should be path to a file
-           repo: the repository base with the task folder
+
+        Parameters
+        ==========
+        result: the result object to save, should be path to a file
+        repo: the repository base with the task folder
         """
         file_name = self.params.get("file_name", file_name) or "result.txt"
         task_folder = os.path.join(repo, self.name)
@@ -232,11 +224,11 @@ class TaskBase(object):
 
     def _save_file(self, result, repo, file_name=None):
         """for a result that exists, move the file to final destination.
- 
-           Parameters
-           ==========
-           result: the result object to save, should be path to a file
-           repo: the repository base with the task folder
+
+        Parameters
+        ==========
+        result: the result object to save, should be path to a file
+        repo: the repository base with the task folder
         """
         if os.path.exists(result):
             name = os.path.basename(result)
@@ -254,10 +246,10 @@ class TaskBase(object):
 
     def _save_json(self, result, repo, file_name=None):
         """for a result that is a dictionary or list, save as json
- 
-           Parameters
-           ==========
-           result: the result object to save, should be dict or list
+
+        Parameters
+        ==========
+        result: the result object to save, should be dict or list
         """
         file_name = self.params.get("file_name", file_name) or "result.json"
         destination = os.path.join(repo, self.name, file_name)
@@ -266,11 +258,11 @@ class TaskBase(object):
 
     def _save_files_list(self, results, repo):
         """If the user provides already existing files, we simply move them
-           into the task folder in the repository.
- 
-           Parameters
-           ==========
-           results: the results to save, should a list of files
+        into the task folder in the repository.
+
+        Parameters
+        ==========
+        results: the results to save, should a list of files
         """
         files = []
         for result in results:
@@ -283,33 +275,33 @@ class TaskBase(object):
 
     def _save_json_list(self, results, repo):
         """A wrapper around save json for a list, handles file naming.
- 
-           Parameters
-           ==========
-           results: the results to save, should a list
+
+        Parameters
+        ==========
+        results: the results to save, should a list
         """
         file_name = self.params.get("file_name", "result.json")
         return self._save_list(results, repo, self._save_json, file_name)
 
     def _save_file_list(self, results, repo):
-        """for a list of results that exist, move the files to 
-           final destination.
- 
-           Parameters
-           ==========
-           results: list of paths to a file, those not existing are skipped
-           repo: the repository base with the task folder
+        """for a list of results that exist, move the files to
+        final destination.
+
+        Parameters
+        ==========
+        results: list of paths to a file, those not existing are skipped
+        repo: the repository base with the task folder
         """
         file_name = self.params.get("file_name", os.path.basename(results))
         return self._save_list(results, repo, self._save_file, file_name)
 
     def _save_text_list(self, results, repo):
         """for a list of general text results, write them to output files.
- 
-           Parameters
-           ==========
-           results: list of string results to write to file
-           repo: the repository base with the task folder
+
+        Parameters
+        ==========
+        results: list of string results to write to file
+        repo: the repository base with the task folder
         """
         file_name = self.params.get("file_name", "result.txt")
         return self._save_list(results, repo, self._save_text, file_name)

--- a/watchme/tasks/decorators.py
+++ b/watchme/tasks/decorators.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from multiprocessing import Process, Queue
 from watchme.logger import bot
@@ -36,13 +30,13 @@ class DecoratorBase(object):
         self.include = self._parse_custom(include)
 
     def _parse_custom(self, listy):
-        """parse an actual list (['one','two','three']) into 
-           a csv list. If we don't have a list, ignore and assume already
-           parsed that way.
- 
-           Parameters
-           ==========
-           listy: the actual list
+        """parse an actual list (['one','two','three']) into
+        a csv list. If we don't have a list, ignore and assume already
+        parsed that way.
+
+        Parameters
+        ==========
+        listy: the actual list
         """
         if listy is None:
             listy = []
@@ -52,7 +46,7 @@ class DecoratorBase(object):
 
     def run(self, *args, **kwargs):
         """run should be implemented by the subclass to run the function or
-           process being monitored
+        process being monitored
         """
         bot.exit("run function must be implemented by subclass.")
 
@@ -70,8 +64,7 @@ class TerminalRunner(DecoratorBase):
         super(TerminalRunner, self).__init__(**kwargs)
 
     def run(self):
-        """run the user provided function
-        """
+        """run the user provided function"""
         try:
             self.process = subprocess.Popen(
                 self.cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE
@@ -85,11 +78,11 @@ class TerminalRunner(DecoratorBase):
     def wait(self, task_name):
         """wait should monitor the running task. run should be called first.
 
-           Parameters
-           ==========
-           task_name: should correspond with the task func (e.g., 
-                      monitor_pid_task for psutils, or
-                      monitor_gpu for gpu tasks.
+        Parameters
+        ==========
+        task_name: should correspond with the task func (e.g.,
+                   monitor_pid_task for psutils, or
+                   monitor_gpu for gpu tasks.
         """
 
         # Parameters for the pid, and to skip sections of results
@@ -134,7 +127,7 @@ class ProcessRunner(DecoratorBase):
 
     def run(self, func, *args, **kwargs):
         """run the user provided function. When we run, we save the function
-           run to self.func, where we can derive the name in self.wait.
+        run to self.func, where we can derive the name in self.wait.
         """
         self.func = func
         args2 = [func, self.queue, args, kwargs]
@@ -145,11 +138,11 @@ class ProcessRunner(DecoratorBase):
     def wait(self, task_name):
         """watch should monitor the running task. run should be called first.
 
-           Parameters
-           ==========
-           task_name: should correspond with the task func (e.g., 
-                      monitor_pid_task for psutils, or
-                      monitor_gpu for gpu tasks.
+        Parameters
+        ==========
+        task_name: should correspond with the task func (e.g.,
+                   monitor_pid_task for psutils, or
+                   monitor_gpu for gpu tasks.
         """
 
         # Parameters for the pid, and to skip sections of results
@@ -183,12 +176,12 @@ class ProcessRunner(DecoratorBase):
 
 def get_task(task_name, params):
     """a helper function to return an instantiated task object, depending
-       on the function name.
+    on the function name.
 
-       Parameters
-       ==========
-       task_name: the name of the task to return
-       params: parameters for the task
+    Parameters
+    ==========
+    task_name: the name of the task to return
+    params: parameters for the task
     """
     if task_name == "monitor_pid_task":
         from watchme.watchers.psutils import Task
@@ -200,8 +193,7 @@ def get_task(task_name, params):
 
 
 def none_to_list(value):
-    """a helper so that function args can be None, and updated to a list.
-    """
+    """a helper so that function args can be None, and updated to a list."""
     if not value:
         value = []
     return value

--- a/watchme/tasks/worker.py
+++ b/watchme/tasks/worker.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.logger import bot
 from watchme.defaults import WATCHME_WORKERS
@@ -37,14 +31,14 @@ class Workers(object):
 
     def run(self, funcs, tasks):
         """run will send a list of tasks, a tuple with arguments, through a function.
-           the arguments should be ordered correctly.
-        
-           Parameters
-           ==========
-           funcs: the functions to run with multiprocessing.pool, a dictionary
-                  with lookup by the task name
-           tasks: a dict of tasks, each task name (key) with a 
-                  tuple of arguments to process
+        the arguments should be ordered correctly.
+
+        Parameters
+        ==========
+        funcs: the functions to run with multiprocessing.pool, a dictionary
+               with lookup by the task name
+        tasks: a dict of tasks, each task name (key) with a
+               tuple of arguments to process
         """
         # Number of tasks must == number of functions
         assert len(funcs) == len(tasks)

--- a/watchme/tests/test_client.py
+++ b/watchme/tests/test_client.py
@@ -1,10 +1,8 @@
 #!/usr/bin/python
 
-# Copyright (C) 2019-2020 Vanessa Sochat.
-
-# This Source Code Form is subject to the terms of the
-# Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-# with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme import get_watcher
 from watchme.command import create_watcher
@@ -60,8 +58,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(self.cli.is_protected(), False)
 
     def test_watcher_task(self):
-        """test adding a task
-        """
+        """test adding a task"""
         print("Testing watcher.add_task")
         self.cli.add_task(
             "task-pancakes", "urls", params=["url@https://www.google.com"]

--- a/watchme/tests/test_decorators.py
+++ b/watchme/tests/test_decorators.py
@@ -1,10 +1,8 @@
 #!/usr/bin/python
 
-# Copyright (C) 2019-2020 Vanessa Sochat.
-
-# This Source Code Form is subject to the terms of the
-# Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-# with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme import get_watcher
 from watchme.command import create_watcher

--- a/watchme/tests/test_utils.py
+++ b/watchme/tests/test_utils.py
@@ -1,10 +1,8 @@
 #!/usr/bin/python
 
-# Copyright (C) 2019-2020 Vanessa Sochat.
-
-# This Source Code Form is subject to the terms of the
-# Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-# with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 import unittest
 import tempfile
@@ -25,8 +23,7 @@ class TestUtils(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
     def test_write_read_files(self):
-        """test_write_read_files will test the functions write_file and read_file
-        """
+        """test_write_read_files will test the functions write_file and read_file"""
         print("Testing utils.write_file")
         from watchme.utils import write_file
 

--- a/watchme/utils/fileio.py
+++ b/watchme/utils/fileio.py
@@ -1,16 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-The watcher is actually a connection to crontab. This is what helps to schedule
-the watched to check for changes at some frequency, and update the files.
-
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 import errno
 import os
@@ -28,8 +18,7 @@ from watchme.logger import bot
 
 
 def get_userhome():
-    """get the user home based on the effective uid
-    """
+    """get the user home based on the effective uid"""
     return os.path.expanduser("~")
 
 
@@ -44,11 +33,11 @@ def get_host():
 
 
 def mkdir_p(path):
-    """ mkdir_p attempts to get the same functionality as mkdir -p
+    """mkdir_p attempts to get the same functionality as mkdir -p
 
-        Paramters
-        =========
-        param path: the path to create.
+    Paramters
+    =========
+    param path: the path to create.
     """
     try:
         os.makedirs(path)
@@ -65,12 +54,12 @@ def mkdir_p(path):
 
 def generate_temporary_file(folder=None, prefix="watchme", ext=None):
     """write a temporary file, in base directory with a particular extension.
-      
-       Parameters
-       ==========
-       folder: the base directory to write in. 
-       prefix: the prefix to use
-       ext: the extension to use.
+
+    Parameters
+    ==========
+    folder: the base directory to write in.
+    prefix: the prefix to use
+    ext: the extension to use.
 
     """
     if folder is None:
@@ -87,13 +76,13 @@ def generate_temporary_file(folder=None, prefix="watchme", ext=None):
 
 def get_tmpdir(prefix="", create=True):
     """get a temporary directory for an operation. If SREGISTRY_TMPDIR
-       is set, return that. Otherwise, return the output of tempfile.mkdtemp
+    is set, return that. Otherwise, return the output of tempfile.mkdtemp
 
-       Parameters
-       ==========
-       prefix: Given a need for a sandbox (or similar), we will need to 
-       create a subfolder *within* the SREGISTRY_TMPDIR.
-       create: boolean to determine if we should create folder (True)
+    Parameters
+    ==========
+    prefix: Given a need for a sandbox (or similar), we will need to
+    create a subfolder *within* the SREGISTRY_TMPDIR.
+    create: boolean to determine if we should create folder (True)
     """
     tmpdir = tempfile.gettempdir()
     prefix = prefix or "watchme-tmp"
@@ -107,8 +96,7 @@ def get_tmpdir(prefix="", create=True):
 
 
 def copyfile(source, destination, force=True):
-    """copy a file from a source to its destination.
-    """
+    """copy a file from a source to its destination."""
     if os.path.exists(destination) and force is True:
         os.remove(destination)
     shutil.copyfile(source, destination)
@@ -125,13 +113,13 @@ def write_file(filename, content, mode="w"):
 
 
 def write_json(json_obj, filename, mode="w", print_pretty=True):
-    """ write_json will (optionally,pretty print) a json object to file
-    
-        Parameters
-        ==========
-        json_obj: the dict to print to json
-        filename: the output file to write to
-        pretty_print: if True, will use nicer formatting
+    """write_json will (optionally,pretty print) a json object to file
+
+    Parameters
+    ==========
+    json_obj: the dict to print to json
+    filename: the output file to write to
+    pretty_print: if True, will use nicer formatting
     """
     with open(filename, mode) as filey:
         if print_pretty:
@@ -142,14 +130,13 @@ def write_json(json_obj, filename, mode="w", print_pretty=True):
 
 
 def print_json(json_obj):
-    """ just dump the json in a "pretty print" format
-    """
+    """just dump the json in a "pretty print" format"""
     return json.dumps(json_obj, indent=4, separators=(",", ": "))
 
 
 def read_file(filename, mode="r", readlines=True):
     """write_file will open a file, "filename" and write content, "content"
-       and properly close the file
+    and properly close the file
     """
     with open(filename, mode) as filey:
         if readlines is True:
@@ -161,7 +148,7 @@ def read_file(filename, mode="r", readlines=True):
 
 def read_json(filename, mode="r"):
     """read_json reads in a json file and returns
-       the data structure as dict.
+    the data structure as dict.
     """
     with open(filename, mode) as filey:
         data = json.load(filey)

--- a/watchme/utils/terminal.py
+++ b/watchme/utils/terminal.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 
 from subprocess import Popen, PIPE, STDOUT
@@ -18,8 +12,7 @@ import shlex
 
 
 def which(software, strip_newline=True):
-    """get_install will return the path to where an executable is installed.
-    """
+    """get_install will return the path to where an executable is installed."""
     if software is None:
         software = "watchme"
     cmd = "which %s" % software
@@ -36,8 +29,7 @@ def which(software, strip_newline=True):
 
 
 def get_installdir():
-    """get_installdir returns the installation directory of the application
-    """
+    """get_installdir returns the installation directory of the application"""
     return os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
 
@@ -88,7 +80,7 @@ def convert2boolean(arg):
 
 def get_watchme_env(prefix="WATCHMEENV_"):
     """get any environment variables that start with WATCMEENV_, return the
-       dictionary to the user.
+    dictionary to the user.
     """
     environ = {}
 

--- a/watchme/version.py
+++ b/watchme/version.py
@@ -1,8 +1,6 @@
-# Copyright (C) 2019-2020 Vanessa Sochat.
-
-# This Source Code Form is subject to the terms of the
-# Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-# with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 
 __version__ = "0.0.28"

--- a/watchme/watchers/__init__.py
+++ b/watchme/watchers/__init__.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.logger import bot, RobotNamer
 from watchme.version import __version__
@@ -68,14 +62,14 @@ class Watcher(object):
 
     def __init__(self, name=None, base=None, create=False, **kwargs):
         """the watcher base loads configuration files for the user (in $HOME)
-           and module, and then stores any arguments given from the caller
+        and module, and then stores any arguments given from the caller
 
-           Parameters
-           ==========
-           name: the watcher name, defaults to github
-           base: the watcher base, will default to $HOME/.watchme
-           create: boolean to create the watcher if doesn't exist (default False)
-           kwargs: should include command line arguments from the client.
+        Parameters
+        ==========
+        name: the watcher name, defaults to github
+        base: the watcher base, will default to $HOME/.watchme
+        create: boolean to create the watcher if doesn't exist (default False)
+        kwargs: should include command line arguments from the client.
 
         """
         # Set the watcher base
@@ -86,12 +80,12 @@ class Watcher(object):
         self.load_config()
 
     def _set_base(self, base=None, create=False):
-        """ set the base for the watcher, ensuring that it exists.
+        """set the base for the watcher, ensuring that it exists.
 
-            Parameters
-            ==========
-            base: the base folder of watcher repos. Uses $HOME/.watchme default
-            create: create the watcher if it doesn't exist (default is False)
+        Parameters
+        ==========
+        base: the base folder of watcher repos. Uses $HOME/.watchme default
+        create: create the watcher if it doesn't exist (default is False)
         """
         if base is None:
             base = WATCHME_BASE_DIR
@@ -116,14 +110,14 @@ class Watcher(object):
 
     def edit_task(self, name, action, key, value=None):
         """edit a task, meaning doing an addition (add), update (update), or
-           "remove", All actions require a value other than remove.
+        "remove", All actions require a value other than remove.
 
-           Parameters
-           ==========
-           name: the name of the task to update
-           action: the action to take (update, add, remove) a parameter
-           key: the key to update
-           value: the value to update
+        Parameters
+        ==========
+        name: the name of the task to update
+        action: the action to take (update, add, remove) a parameter
+        key: the key to update
+        value: the value to update
         """
 
         if not self.has_task(name):
@@ -165,11 +159,11 @@ class Watcher(object):
 
     def has_section(self, name):
         """returns True or False to indicate if the watcher has a specified
-           section. To get a task, use self.has_task.
+        section. To get a task, use self.has_task.
 
-           Parameters
-           ==========
-           name: the name of the section to check for.
+        Parameters
+        ==========
+        name: the name of the section to check for.
         """
         self.load_config()
         if name in self.config._sections:
@@ -179,9 +173,9 @@ class Watcher(object):
 
     def load_config(self):
         """load a configuration file, and set the active setting for the watcher
-           if the file doesn't exist, the function will exit and prompt the user 
-           to create the watcher first. If the watcher section isn't yet defined,
-           it will be written with a default active status set to false.
+        if the file doesn't exist, the function will exit and prompt the user
+        to create the watcher first. If the watcher section isn't yet defined,
+        it will be written with a default active status set to false.
         """
         if not hasattr(self, "config"):
 
@@ -199,11 +193,11 @@ class Watcher(object):
 
     def _get_params_dict(self, pairs):
         """iterate through parameters, make keys lowercase, and ensure
-           valid format.
+        valid format.
 
-           Parameters
-           ==========
-           pairs: a list of key@value pairs to set.
+        Parameters
+        ==========
+        pairs: a list of key@value pairs to set.
         """
         params = {}
         for pair in pairs:
@@ -223,16 +217,16 @@ class Watcher(object):
 
     def add_task(self, task, task_type, params, force=False, active="true"):
         """add a task, meaning ensuring that the type is valid, and that
-           the parameters are valid for the task.
+        the parameters are valid for the task.
 
-           Parameters
-           ==========
-           task: the Task object to add, should have a name and params and
-                 be child of watchme.tasks.TaskBase
-           task_type: must be in WATCHME_TASK_TYPES, meaning a client exists
-           params: list of parameters to be validated (key@value)
-           force: if task already exists, overwrite
-           active: add the task as active (default "true")
+        Parameters
+        ==========
+        task: the Task object to add, should have a name and params and
+              be child of watchme.tasks.TaskBase
+        task_type: must be in WATCHME_TASK_TYPES, meaning a client exists
+        params: list of parameters to be validated (key@value)
+        force: if task already exists, overwrite
+        active: add the task as active (default "true")
         """
 
         # Check again, in case user calling from client
@@ -275,17 +269,17 @@ class Watcher(object):
     def _add_task(self, task, force=False, active="true"):
         """add a new task to the watcher, meaning we:
 
-           1. Check first that the task doesn't already exist (if the task
-              exists, we only add if force is set to true)
-           2. Validate the task (depends on the task)
-           3. write the task to the helper config file, if valid.
+        1. Check first that the task doesn't already exist (if the task
+           exists, we only add if force is set to true)
+        2. Validate the task (depends on the task)
+        3. write the task to the helper config file, if valid.
 
-           Parameters
-           ==========
-           task: the Task object to add, should have a name and params and
-                 be child of watchme.tasks.TaskBase
-           force: if task already exists, overwrite
-           active: add the task as active (default "true")
+        Parameters
+        ==========
+        task: the Task object to add, should have a name and params and
+              be child of watchme.tasks.TaskBase
+        force: if task already exists, overwrite
+        active: add the task as active (default "true")
         """
         self.load_config()
 
@@ -315,8 +309,7 @@ class Watcher(object):
     # Delete
 
     def delete(self):
-        """delete the entire watcher, only if not protected. Cannot be undone.
-        """
+        """delete the entire watcher, only if not protected. Cannot be undone."""
         self.load_config()
 
         # Check for protection
@@ -338,11 +331,11 @@ class Watcher(object):
 
     def remove_task(self, task):
         """remove a task from the watcher repo, if it exists, and the
-           watcher is not frozen.
+        watcher is not frozen.
 
-           Parameters
-           ==========
-           task: the name of the task to remove
+        Parameters
+        ==========
+        task: the name of the task to remove
         """
         if self.get_section(task) is not None:
             if self.is_frozen():
@@ -364,14 +357,14 @@ class Watcher(object):
 
     def inspect(self, tasks=None, create_command=False):
         """inspect a watcher, or one or more tasks belonging to it. This means
-           printing the configuration for the entire watcher (if tasks is None)
-           or just for one or more tasks.
- 
-           Parameters
-           ==========
-           tasks: one or more tasks to inspect (None will show entire file)
-           create_command: if True, given one or more tasks, print the command
-                           to create them.
+        printing the configuration for the entire watcher (if tasks is None)
+        or just for one or more tasks.
+
+        Parameters
+        ==========
+        tasks: one or more tasks to inspect (None will show entire file)
+        create_command: if True, given one or more tasks, print the command
+                        to create them.
         """
         self.load_config()
         if tasks is None:
@@ -400,24 +393,24 @@ class Watcher(object):
 
     def protect(self, status="on"):
         """protect a watcher, meaning that it cannot be deleted. This does
-           not influence removing a task. To freeze the entire watcher,
-           use the freeze() function.
+        not influence removing a task. To freeze the entire watcher,
+        use the freeze() function.
         """
         self._set_status("watcher", "protected", status)
         git_commit(self.repo, self.name, "PROTECT %s" % status)
         self.print_section("watcher")
 
     def freeze(self):
-        """freeze a watcher, meaning that it along with its tasks cannot be 
-           deleted. This does not prevent the user from manual editing.
+        """freeze a watcher, meaning that it along with its tasks cannot be
+        deleted. This does not prevent the user from manual editing.
         """
         self._set_status("watcher", "frozen", "on")
         git_commit(self.repo, self.name, "FREEZE")
         self.print_section("watcher")
 
     def unfreeze(self):
-        """freeze a watcher, meaning that it along with its tasks cannot be 
-           deleted. This does not prevent the user from manual editing.
+        """freeze a watcher, meaning that it along with its tasks cannot be
+        deleted. This does not prevent the user from manual editing.
         """
         self._set_status("watcher", "frozen", "off")
         git_commit(self.repo, self.name, "UNFREEZE")
@@ -425,12 +418,12 @@ class Watcher(object):
 
     def _set_status(self, section, setting, value):
         """a helper function to set a status, ensuring that status value
-           is in "on" or "off"
+        is in "on" or "off"
 
-           Parameters
-           ==========
-           status: one of "on" or "off"
-           name: a value to set status for.
+        Parameters
+        ==========
+        status: one of "on" or "off"
+        name: a value to set status for.
         """
         if value not in ["on", "off"]:
             bot.exit('Status must be "on" or "off"')
@@ -439,8 +432,8 @@ class Watcher(object):
 
     def is_protected(self):
         """return a boolean to indicate if the watcher is protected or frozen.
-           protected indicates no delete to the watcher, but allowed delete
-           to tasks, frozen indicates no change of anything.
+        protected indicates no delete to the watcher, but allowed delete
+        to tasks, frozen indicates no change of anything.
         """
         protected = False
         for status in ["protected", "frozen"]:
@@ -450,8 +443,8 @@ class Watcher(object):
 
     def is_frozen(self):
         """return a boolean to indicate if the watcher is frozen.
-           protected indicates no delete to the watcher, but allowed delete
-           to tasks, frozen indicates no change of anything.
+        protected indicates no delete to the watcher, but allowed delete
+        to tasks, frozen indicates no change of anything.
         """
         if self.get_setting("watcher", "frozen") == "on":
             return True
@@ -461,12 +454,12 @@ class Watcher(object):
 
     def _active_status(self, status="true", name=None):
         """a general function to change the status, used by activate and
-           deactivate.
- 
-           Parameters
-           ==========
-           status: must be one of true, false
-           name: if not None, we are deactivating a task (not the watcher)
+        deactivate.
+
+        Parameters
+        ==========
+        status: must be one of true, false
+        name: if not None, we are deactivating a task (not the watcher)
         """
         # Load the configuration, if not loaded
         self.load_config()
@@ -498,14 +491,13 @@ class Watcher(object):
         return message
 
     def activate(self, task=None):
-        """turn the active status of a watcher to True
-        """
+        """turn the active status of a watcher to True"""
         message = self._active_status("true", task)
         git_commit(self.repo, self.name, message)
 
     def deactivate(self, task=None):
         """turn the active status of a watcher to false. If a task is provided,
-           update the config value for the task to be false.
+        update the config value for the task to be false.
         """
         # If no task defined, user wants to deactiate watcher
         message = self._active_status("false", task)
@@ -513,7 +505,7 @@ class Watcher(object):
 
     def is_active(self, task=None):
         """determine if the watcher is active by reading from the config directly
-           if a task name is provided, check the active status of the task
+        if a task name is provided, check the active status of the task
         """
         if task is None:
             task = "watcher"
@@ -525,12 +517,12 @@ class Watcher(object):
 
     def get_decorator(self, name):
         """instantiate a task object for a decorator. Decorators must start
-           with "decorator-" and since they are run on the fly, we don't
-           find them in the config.
+        with "decorator-" and since they are run on the fly, we don't
+        find them in the config.
 
-           Parameters
-           ==========
-           name: the name of the task to load
+        Parameters
+        ==========
+        name: the name of the task to load
         """
 
         task = None
@@ -550,7 +542,7 @@ class Watcher(object):
 
     def has_task(self, name):
         """returns True or False to indicate if the watcher has a specified
-           task.
+        task.
         """
         self.load_config()
         if self.has_section(name) and name.startswith("task"):
@@ -559,12 +551,12 @@ class Watcher(object):
 
     def get_task(self, name):
         """get a particular task, based on the name. This is where each type
-           of class should check the "type" parameter from the config, and
-           import the correct Task class.
+        of class should check the "type" parameter from the config, and
+        import the correct Task class.
 
-           Parameters
-           ==========
-           name: the name of the task to load
+        Parameters
+        ==========
+        name: the name of the task to load
         """
         self.load_config()
 
@@ -602,13 +594,13 @@ class Watcher(object):
 
     def _task_selected(self, task, regexp=None, active=True):
         """check if a task is active and (if defined) passes user provided
-           task names or regular expressions.
+        task names or regular expressions.
 
-           Parameters
-           ==========
-           task: the task object to check
-           regexp: an optional regular expression (or name) to check
-           active: a task is selected if it's active (default True)
+        Parameters
+        ==========
+        task: the task object to check
+        regexp: an optional regular expression (or name) to check
+        active: a task is selected if it's active (default True)
         """
         selected = True
 
@@ -632,15 +624,15 @@ class Watcher(object):
 
     def get_tasks(self, regexp=None, quiet=False, active=True):
         """get the tasks for a watcher, possibly matching a regular expression.
-           A list of dictionaries is returned, each holding the parameters for
-           a task. "uri" will hold the task (folder) name, active
+        A list of dictionaries is returned, each holding the parameters for
+        a task. "uri" will hold the task (folder) name, active
 
-           Parameters
-           ==========
-           regexp: if supplied, the user wants to run only tasks that match
-                   a particular pattern
-           quiet: If quiet, don't print the number of tasks found
-           active: only return active tasks (default True)
+        Parameters
+        ==========
+        regexp: if supplied, the user wants to run only tasks that match
+                a particular pattern
+        quiet: If quiet, don't print the number of tasks found
+        active: only return active tasks (default True)
         """
         self.load_config()
 
@@ -663,22 +655,22 @@ class Watcher(object):
 
     def run_tasks(self, queue, parallel=True, show_progress=True):
         """this run_tasks function takes a list of Task objects, each
-           potentially a different kind of task, and extracts the parameters
-           with task.export_params(), and the running function with 
-           task.export_func(), and hands these over to the multiprocessing
-           worker. It's up to the Task to return some correct function
-           from it's set of task functions that correspond with the variables.
+        potentially a different kind of task, and extracts the parameters
+        with task.export_params(), and the running function with
+        task.export_func(), and hands these over to the multiprocessing
+        worker. It's up to the Task to return some correct function
+        from it's set of task functions that correspond with the variables.
 
-           Examples
-           ========
+        Examples
+        ========
 
-           funcs
-           {'task-reddit-hpc': <function watchme.watchers.urls.tasks.get_task>}
+        funcs
+        {'task-reddit-hpc': <function watchme.watchers.urls.tasks.get_task>}
 
-           tasks
-           {'task-reddit-hpc': [('url', 'https://www.reddit.com/r/hpc'),
-                                ('active', 'true'),
-                                ('type', 'urls')]}
+        tasks
+        {'task-reddit-hpc': [('url', 'https://www.reddit.com/r/hpc'),
+                             ('active', 'true'),
+                             ('type', 'urls')]}
         """
         if parallel is True:
             return self._run_parallel(queue, show_progress)
@@ -702,12 +694,12 @@ class Watcher(object):
         return results
 
     def _run_parallel(self, queue, show_progress=True):
-        """ run tasks in parallel using the Workers class. Returns a dictionary
-            (lookup) wit results, with the key being the task name
+        """run tasks in parallel using the Workers class. Returns a dictionary
+        (lookup) wit results, with the key being the task name
 
-            Parameters
-            ==========
-            queue: the list of task objects to run
+        Parameters
+        ==========
+        queue: the list of task objects to run
         """
         from watchme.tasks.worker import Workers
 
@@ -727,22 +719,22 @@ class Watcher(object):
     def run(self, regexp=None, parallel=True, test=False, show_progress=True):
         """run the watcher, which should be done via the crontab, including:
 
-             - checks: the instantiation of the client already ensures that 
-                       the watcher folder exists, and has a configuration,
-                       and it loads.
-             - parse: parse the tasks to be run
-             - start: run the tasks that are defined for the watcher.
-             - finish: after completion, commit to the repository changed files
+          - checks: the instantiation of the client already ensures that
+                    the watcher folder exists, and has a configuration,
+                    and it loads.
+          - parse: parse the tasks to be run
+          - start: run the tasks that are defined for the watcher.
+          - finish: after completion, commit to the repository changed files
 
-           Parameters
-           ==========
-           regexp: if supplied, the user wants to run only tasks that match
-                   a particular pattern         
-           parallel: if True, use multiprocessing to run tasks (True)
-                     each watcher should have this setup ready to go. 
-           test: run in test mode (no saving of results)
-           show_progress: if True, show progress bar instead of task information
-                          (defaults to True)
+        Parameters
+        ==========
+        regexp: if supplied, the user wants to run only tasks that match
+                a particular pattern
+        parallel: if True, use multiprocessing to run tasks (True)
+                  each watcher should have this setup ready to go.
+        test: run in test mode (no saving of results)
+        show_progress: if True, show progress bar instead of task information
+                       (defaults to True)
         """
 
         # Step 1: determine if the watcher is active.
@@ -765,14 +757,14 @@ class Watcher(object):
 
     def finish_runs(self, results):
         """finish runs should take a dictionary of results, with keys as the
-           folder name, and for each, depending on the result type,
-           write the result to file (or update file) and then commit
-           to git.
+        folder name, and for each, depending on the result type,
+        write the result to file (or update file) and then commit
+        to git.
 
-           Parameters
-           ==========
-           results: a dictionary of tasks, with keys as the task name, and
-                    values as the result.
+        Parameters
+        ==========
+        results: a dictionary of tasks, with keys as the task name, and
+                 values as the result.
         """
         if results is None:
             return

--- a/watchme/watchers/data.py
+++ b/watchme/watchers/data.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.logger import bot
 from watchme.command import get_commits, git_show, git_date
@@ -28,15 +22,15 @@ def export_dict(
 ):
     """Export a data frame of changes for a filename over time.
 
-       Parameters
-       ==========
-       task: the task folder for the watcher to look in
-       name: the name of the watcher, defaults to the client's
-       base: the base of watchme to look for the task folder
-       from_commit: the commit to start at
-       to_commit: the commit to go to
-       grep: the expression to match (not used if None)
-       filename: the filename to filter to. Includes all files if not specified.
+    Parameters
+    ==========
+    task: the task folder for the watcher to look in
+    name: the name of the watcher, defaults to the client's
+    base: the base of watchme to look for the task folder
+    from_commit: the commit to start at
+    to_commit: the commit to go to
+    grep: the expression to match (not used if None)
+    filename: the filename to filter to. Includes all files if not specified.
     """
     if name is None:
         name = self.name

--- a/watchme/watchers/gpu/__init__.py
+++ b/watchme/watchers/gpu/__init__.py
@@ -1,13 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from .pynvml import nvmlInit
 from watchme.tasks import TaskBase
@@ -42,7 +35,7 @@ class Task(TaskBase):
 
     def assert_gpu(self):
         """has_gpu is run from the getgo to see if there are any libraries
-           for the client to read from. If not, we alert the user and exit.
+        for the client to read from. If not, we alert the user and exit.
         """
         try:
             nvmlInit()
@@ -51,11 +44,11 @@ class Task(TaskBase):
 
     def export_func(self):
         """this function should return the correct task (from the tasks.py
-           in the same folder) based on some logic of the params that are given
-           by the user (self.params). If there is only one kind of function for
-           the task, it's fairly easy to import and return it here. This
-           function should take no arguments, but instead use the self.params
-           already provided in the client.
+        in the same folder) based on some logic of the params that are given
+        by the user (self.params). If there is only one kind of function for
+        the task, it's fairly easy to import and return it here. This
+        function should take no arguments, but instead use the self.params
+        already provided in the client.
         """
         name = self.params.get("func", "gpu_task")
 

--- a/watchme/watchers/gpu/decorators.py
+++ b/watchme/watchers/gpu/decorators.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from functools import wraps
 from watchme.logger import bot
@@ -15,26 +9,26 @@ from watchme import get_watcher
 
 
 def monitor_gpu(*args, **kwargs):
-    """a decorator to monitor a function every 3 (or user specified) seconds. 
-       We include one or more task names that include data we want to extract.
-       we get the pid of the running function, and then use the
-       gpu_task from gpu to watch it. The functools "wraps"
-       ensures that the (fargs, fkwargs) are passed from the calling function
-       despite the wrapper. The following parameters can be provided to
-       "monitor resources"
+    """a decorator to monitor a function every 3 (or user specified) seconds.
+    We include one or more task names that include data we want to extract.
+    we get the pid of the running function, and then use the
+    gpu_task from gpu to watch it. The functools "wraps"
+    ensures that the (fargs, fkwargs) are passed from the calling function
+    despite the wrapper. The following parameters can be provided to
+    "monitor resources"
 
-       Parameters
-       ==========
-       watcher: the watcher instance to use, used to save data to a "task"
-                folder that starts with "decorator-<name<"
-       seconds: how often to collect data during the run.
-       only: ignore skip and include, only include this custom subset
-       skip: Fields in the result to skip (list).
-       include: Fields in the result to include back in (list).
-       create: whether to create the watcher on the fly (default False, must
-               exist)
-       name: the suffix of the decorator-gpu-<name> folder. If not provided,
-             defaults to the function name
+    Parameters
+    ==========
+    watcher: the watcher instance to use, used to save data to a "task"
+             folder that starts with "decorator-<name<"
+    seconds: how often to collect data during the run.
+    only: ignore skip and include, only include this custom subset
+    skip: Fields in the result to skip (list).
+    include: Fields in the result to include back in (list).
+    create: whether to create the watcher on the fly (default False, must
+            exist)
+    name: the suffix of the decorator-gpu-<name> folder. If not provided,
+          defaults to the function name
     """
 
     def inner(func):

--- a/watchme/watchers/gpu/pynvml.py
+++ b/watchme/watchers/gpu/pynvml.py
@@ -1,15 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-The original license (2011-2015) is included below.
-
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 #####
 # Copyright (c) 2011-2015, NVIDIA Corporation.  All rights reserved.
@@ -424,19 +415,19 @@ c_nvmlUnit_t = POINTER(struct_c_nvmlUnit_t)
 
 class _PrintableStructure(Structure):
     """Abstract class that produces nicer __str__ output than ctypes.Structure.
-       e.g. instead of:
-          >>> print(str(obj))
-             <class_name object at 0x7fdf82fef9e0>
-       this class will print
-         class_name(field_name: formatted_value, field_name: formatted_value)
-         _fmt_ dictionary of <str _field_ name> -> <str format>
-        e.g. class that has _field_ 'hex_value', c_uint could be formatted with
-       _fmt_ = {"hex_value" : "%08X"}
-       to produce nicer output.
-       Default fomratting string for all fields can be set with key "<default>" like:
-       _fmt_ = {"<default>" : "%d MHz"} # e.g all values are numbers in MHz.
-       If not set it's assumed to be just "%s"
-      Exact format of returned str from this class is subject to change in the future.
+     e.g. instead of:
+        >>> print(str(obj))
+           <class_name object at 0x7fdf82fef9e0>
+     this class will print
+       class_name(field_name: formatted_value, field_name: formatted_value)
+       _fmt_ dictionary of <str _field_ name> -> <str format>
+      e.g. class that has _field_ 'hex_value', c_uint could be formatted with
+     _fmt_ = {"hex_value" : "%08X"}
+     to produce nicer output.
+     Default fomratting string for all fields can be set with key "<default>" like:
+     _fmt_ = {"<default>" : "%d MHz"} # e.g all values are numbers in MHz.
+     If not set it's assumed to be just "%s"
+    Exact format of returned str from this class is subject to change in the future.
     """
 
     _fmt_ = {}

--- a/watchme/watchers/gpu/tasks.py
+++ b/watchme/watchers/gpu/tasks.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.utils import get_watchme_env
 from .pynvml import nvmlInit, nvmlShutdown
@@ -15,13 +9,13 @@ from watchme.watchers.gpu import pynvml
 
 def gpu_task(**kwargs):
     """Get variables about the gpu of the host. No parameters are required.
-       We've already instantited the Task object and have checked that
-       the calling host has nvml GPU
+    We've already instantited the Task object and have checked that
+    the calling host has nvml GPU
 
-       Parameters
-       ==========
-       skip: an optional list of (comma separated) fields to skip. Can be in
-             net_io_counters,net_connections,net_if_address,net_if_stats
+    Parameters
+    ==========
+    skip: an optional list of (comma separated) fields to skip. Can be in
+          net_io_counters,net_connections,net_if_address,net_if_stats
     """
     nvmlInit()
 
@@ -183,13 +177,13 @@ def gpu_task(**kwargs):
 
 
 def _filter_result(results, skip):
-    """a helper function to filter a dictionary based on a list of keys to 
-       skip. We also add variables from the environment.
-    
-       Parameters
-       ==========
-       results: a dictionary of results
-       skip: a list of keys to remove/filter from the result.
+    """a helper function to filter a dictionary based on a list of keys to
+    skip. We also add variables from the environment.
+
+    Parameters
+    ==========
+    results: a dictionary of results
+    skip: a list of keys to remove/filter from the result.
     """
 
     # Add any environment variables prefixed wit WATCHMEENV_

--- a/watchme/watchers/psutils/__init__.py
+++ b/watchme/watchers/psutils/__init__.py
@@ -1,13 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.tasks import TaskBase
 from watchme.logger import bot
@@ -40,11 +33,11 @@ class Task(TaskBase):
 
     def export_func(self):
         """this function should return the correct task (from the tasks.py
-           in the same folder) based on some logic of the params that are given
-           by the user (self.params). If there is only one kind of function for
-           the task, it's fairly easy to import and return it here. This
-           function should take no arguments, but instead use the self.params
-           already provided in the client.
+        in the same folder) based on some logic of the params that are given
+        by the user (self.params). If there is only one kind of function for
+        the task, it's fairly easy to import and return it here. This
+        function should take no arguments, but instead use the self.params
+        already provided in the client.
         """
         name = self.params.get("func", "cpu_task")
 

--- a/watchme/watchers/psutils/decorators.py
+++ b/watchme/watchers/psutils/decorators.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from functools import wraps
 from watchme.logger import bot
@@ -15,26 +9,26 @@ from watchme import get_watcher
 
 
 def monitor_resources(*args, **kwargs):
-    """a decorator to monitor a function every 3 (or user specified) seconds. 
-       We include one or more task names that include data we want to extract.
-       we get the pid of the running function, and then use the
-       monitor_pid_task from psutils to watch it. The functools "wraps"
-       ensures that the (fargs, fkwargs) are passed from the calling function
-       despite the wrapper. The following parameters can be provided to
-       "monitor resources"
+    """a decorator to monitor a function every 3 (or user specified) seconds.
+    We include one or more task names that include data we want to extract.
+    we get the pid of the running function, and then use the
+    monitor_pid_task from psutils to watch it. The functools "wraps"
+    ensures that the (fargs, fkwargs) are passed from the calling function
+    despite the wrapper. The following parameters can be provided to
+    "monitor resources"
 
-       Parameters
-       ==========
-       watcher: the watcher instance to use, used to save data to a "task"
-                folder that starts with "decorator-<name<"
-       seconds: how often to collect data during the run.
-       only: ignore skip and include, only include this custom subset
-       skip: Fields in the result to skip (list).
-       include: Fields in the result to include back in (list).
-       create: whether to create the watcher on the fly (default False, must
-               exist)
-       name: the suffix of the decorator-psutils-<name> folder. If not provided,
-             defaults to the function name
+    Parameters
+    ==========
+    watcher: the watcher instance to use, used to save data to a "task"
+             folder that starts with "decorator-<name<"
+    seconds: how often to collect data during the run.
+    only: ignore skip and include, only include this custom subset
+    skip: Fields in the result to skip (list).
+    include: Fields in the result to include back in (list).
+    create: whether to create the watcher on the fly (default False, must
+            exist)
+    name: the suffix of the decorator-psutils-<name> folder. If not provided,
+          defaults to the function name
     """
 
     def inner(func):

--- a/watchme/watchers/psutils/tasks.py
+++ b/watchme/watchers/psutils/tasks.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from subprocess import check_output, CalledProcessError
 from watchme.utils import get_watchme_env
@@ -16,14 +10,14 @@ import psutil
 
 def monitor_pid_task(**kwargs):
     """monitor a specific process. This function can be used as a task, or
-       is (most likely used) for the psutils.decorators. A pid parameter
-       is required.
+    is (most likely used) for the psutils.decorators. A pid parameter
+    is required.
 
-       Parameters
-       ==========
-       skip: an optional list of (comma separated) fields to skip. Can be in
-             net_io_counters,net_connections,net_if_address,net_if_stats
-       pid: the process id or name (required)
+    Parameters
+    ==========
+    skip: an optional list of (comma separated) fields to skip. Can be in
+          net_io_counters,net_connections,net_if_address,net_if_stats
+    pid: the process id or name (required)
     """
     pid = kwargs.get("pid", None)
 
@@ -177,10 +171,10 @@ def monitor_pid_task(**kwargs):
 def cpu_task(**kwargs):
     """Get variables about the cpu of the host. No parameters are required.
 
-       Parameters
-       ==========
-       skip: an optional list of (comma separated) fields to skip. Can be in
-             net_io_counters,net_connections,net_if_address,net_if_stats
+    Parameters
+    ==========
+    skip: an optional list of (comma separated) fields to skip. Can be in
+          net_io_counters,net_connections,net_if_address,net_if_stats
     """
     result = {}
 
@@ -200,10 +194,10 @@ def cpu_task(**kwargs):
 def python_task(**kwargs):
     """Get modules, version, etc. about currently running python
 
-       Parameters
-       ==========
-       skip: an optional list of (comma separated) fields to skip. Can be in
-             net_io_counters,net_connections,net_if_address,net_if_stats
+    Parameters
+    ==========
+    skip: an optional list of (comma separated) fields to skip. Can be in
+          net_io_counters,net_connections,net_if_address,net_if_stats
     """
     # A comma separated list of parameters to not include
     skip = kwargs.get("skip", "")
@@ -224,10 +218,10 @@ def python_task(**kwargs):
 def system_task(**kwargs):
     """Get basic system info, unlikely to change.
 
-       Parameters
-       ==========
-       skip: an optional list of (comma separated) fields to skip. Can be in
-             net_io_counters,net_connections,net_if_address,net_if_stats
+    Parameters
+    ==========
+    skip: an optional list of (comma separated) fields to skip. Can be in
+          net_io_counters,net_connections,net_if_address,net_if_stats
     """
     # A comma separated list of parameters to not include
     skip = kwargs.get("skip", "")
@@ -271,8 +265,7 @@ def system_task(**kwargs):
 
 
 def memory_task(**kwargs):
-    """Get values for memory of the host. No parameters are required.
-    """
+    """Get values for memory of the host. No parameters are required."""
 
     result = {}
 
@@ -287,8 +280,7 @@ def memory_task(**kwargs):
 
 
 def users_task(**kwargs):
-    """Get values for current users
-    """
+    """Get values for current users"""
 
     result = {"users": []}
     for user in psutil.users():
@@ -302,8 +294,7 @@ def users_task(**kwargs):
 
 
 def sensors_task(**kwargs):
-    """Get values from system sensors like fans, temperature, battery
-    """
+    """Get values from system sensors like fans, temperature, battery"""
 
     # A comma separated list of parameters to not include
     skip = kwargs.get("skip", "")
@@ -349,10 +340,10 @@ def sensors_task(**kwargs):
 def net_task(**kwargs):
     """Get values for networking on the host
 
-       Parameters
-       ==========
-       skip: an optional list of (comma separated) fields to skip. Can be in
-             net_io_counters,net_connections,net_if_address,net_if_stats
+    Parameters
+    ==========
+    skip: an optional list of (comma separated) fields to skip. Can be in
+          net_io_counters,net_connections,net_if_address,net_if_stats
     """
     result = {}
 
@@ -418,11 +409,11 @@ def net_task(**kwargs):
 def disk_task(**kwargs):
     """Get values for disks on the host
 
-       Parameters
-       ==========
-       disk_usage: an optional path to get disk usage for.
-       skip: an optional list of (comma separated) fields to skip. Can be in
-             net_io_counters,net_connections,net_if_address,net_if_stats
+    Parameters
+    ==========
+    disk_usage: an optional path to get disk usage for.
+    skip: an optional list of (comma separated) fields to skip. Can be in
+          net_io_counters,net_connections,net_if_address,net_if_stats
 
     """
     # A comma separated list of parameters to not include
@@ -448,13 +439,13 @@ def disk_task(**kwargs):
 
 
 def _filter_result(result, skip):
-    """a helper function to filter a dictionary based on a list of keys to 
-       skip. We also add variables from the environment.
-    
-       Parameters
-       ==========
-       result: a dictionary of results
-       skip: a list of keys to remove/filter from the result.
+    """a helper function to filter a dictionary based on a list of keys to
+    skip. We also add variables from the environment.
+
+    Parameters
+    ==========
+    result: a dictionary of results
+    skip: a list of keys to remove/filter from the result.
     """
 
     # Add any environment variables prefixed wit WATCHMEENV_
@@ -470,10 +461,10 @@ def _filter_result(result, skip):
 
 def _get_pid(name):
     """used to get the pid of a process, by name
-       
-       Parameters
-       ==========
-       name: the name of the process to get.
+
+    Parameters
+    ==========
+    name: the name of the process to get.
     """
     try:
         pid = check_output(["pidof", name])

--- a/watchme/watchers/results/__init__.py
+++ b/watchme/watchers/results/__init__.py
@@ -1,13 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.tasks import TaskBase
 from watchme.logger import bot
@@ -18,7 +11,7 @@ import sys
 
 class Task(TaskBase):
     """a results task aims to use WatchMe as a database, meaning the functions
-       are optimized to collect and record results."""
+    are optimized to collect and record results."""
 
     required_params = []
 
@@ -34,11 +27,11 @@ class Task(TaskBase):
 
     def export_func(self):
         """this function should return the correct task (from the tasks.py
-           in the same folder) based on some logic of the params that are given
-           by the user (self.params). If there is only one kind of function for
-           the task, it's fairly easy to import and return it here. This
-           function should take no arguments, but instead use the self.params
-           already provided in the client.
+        in the same folder) based on some logic of the params that are given
+        by the user (self.params). If there is only one kind of function for
+        the task, it's fairly easy to import and return it here. This
+        function should take no arguments, but instead use the self.params
+        already provided in the client.
         """
         name = self.params.get("func", "from_env_task")
 

--- a/watchme/watchers/results/tasks.py
+++ b/watchme/watchers/results/tasks.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.utils import get_tmpdir, get_watchme_env, write_file
 import os
@@ -15,17 +9,17 @@ import shutil
 
 def from_env_task(**kwargs):
     """Get some set of variables from the environment. We look for those
-       defined in kwargs, but also any in the environment that start with
-       the prefix WATCHMENEV_. They are saved to files that are equivalently
-       named, and the idea is that we can track a changing (single) result,
-       meaning that the timestamp is meaningful, or we can track
-       values for many different results, so the timestamps just serve to
-       record when each was recorded.
+    defined in kwargs, but also any in the environment that start with
+    the prefix WATCHMENEV_. They are saved to files that are equivalently
+    named, and the idea is that we can track a changing (single) result,
+    meaning that the timestamp is meaningful, or we can track
+    values for many different results, so the timestamps just serve to
+    record when each was recorded.
 
-       Parameters
-       ==========
-       *: any number of parameters from the task configuration that will
-          be looked for in the environment.
+    Parameters
+    ==========
+    *: any number of parameters from the task configuration that will
+       be looked for in the environment.
     """
     results = []
 

--- a/watchme/watchers/schedule.py
+++ b/watchme/watchers/schedule.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.logger import bot
 from watchme.utils import which
@@ -17,8 +11,8 @@ from crontab import CronTab
 
 def remove_schedule(self, name=None, quiet=False):
     """remove a scheduled item from crontab, this is based on the watcher
-       name. By default, we use the watcher instance name, however you
-       can specify a custom name if desired.
+    name. By default, we use the watcher instance name, however you
+    can specify a custom name if desired.
     """
     if name is None:
         name = self.name
@@ -38,16 +32,14 @@ def remove_schedule(self, name=None, quiet=False):
 
 
 def has_schedule(self, must_exist=False):
-    """determine if a watcher already has a schedule, as a warning to the user.
-    """
+    """determine if a watcher already has a schedule, as a warning to the user."""
     if self.get_job(must_exist=False) is None:
         return False
     return True
 
 
 def get_job(self, must_exist=True):
-    """return the job to the user, or None
-    """
+    """return the job to the user, or None"""
     # Find the job based on a standard of comment
     cron = self.get_crontab()
     comment = "watchme-%s" % self.name
@@ -62,18 +54,17 @@ def get_job(self, must_exist=True):
 
 
 def get_crontab(self):
-    """get an instance of the user's crontab. We use the running user.
-    """
+    """get an instance of the user's crontab. We use the running user."""
     # Create an instance of the user's crontab
     return CronTab(user=True)
 
 
 def update_schedule(self, minute=12, hour="*", month="*", day="*"):
     """update a scheduled item from the crontab, with a new entry. This
-       first looks for the entry (and removes it) and then clls the new_
-       schedule function to write a new one. This function is intended
-       to be used by a client from within Python, and isn't exposed from
-       the command line.
+    first looks for the entry (and removes it) and then clls the new_
+    schedule function to write a new one. This function is intended
+    to be used by a client from within Python, and isn't exposed from
+    the command line.
     """
     job = self.get_job(must_exist=True)
 
@@ -88,7 +79,7 @@ def update_schedule(self, minute=12, hour="*", month="*", day="*"):
 
 def clear_schedule(self):
     """clear all cron jobs associated with the watcher. To remove jobs
-       associated with a single watcher, use remove_schedule
+    associated with a single watcher, use remove_schedule
     """
     cron = self.get_crontab()
     bot.info("Clearing jobs associated with all watchers")
@@ -103,24 +94,24 @@ def schedule(
     self, minute=12, hour=0, month="*", day="*", weekday="*", job=None, force=False
 ):
     """schedule the watcher to run at some frequency to update record of pages.
-       By default, the task will run at 12 minutes passed midnight, daily.
-       You can change the variables to change the frequency. See
-       https://crontab.guru/ to get a setting that works for you.
+    By default, the task will run at 12 minutes passed midnight, daily.
+    You can change the variables to change the frequency. See
+    https://crontab.guru/ to get a setting that works for you.
 
-            Hourly:	0 * * * *
-            Daily:	0 0 * * *    (midnight) default
-            weekly	0 0 * * 0
-            monthly	0 0 1 * *
-            yearly	0 0 1 1 *
+    Hourly:  0 * * * *
+    Daily:   0 0 * * *    (midnight) default
+    weekly:  0 0 * * 0
+    monthly: 0 0 1 * *
+    yearly:  0 0 1 1 *
 
-       Parameters
-       ==========
-       minute: must be within 1 and 60, or set to "*" for every minute
-       hour: must be within 0 through 23 or set to *
-       month: must be within 1 and 12, or *
-       day: must be between 1 and 31, or *
-       weekday: must be between 0 and 6 or *
-       job: if provided, assumes we are updated an existing entry.
+    Parameters
+    ==========
+    minute: must be within 1 and 60, or set to "*" for every minute
+    hour: must be within 0 through 23 or set to *
+    month: must be within 1 and 12, or *
+    day: must be between 1 and 31, or *
+    weekday: must be between 0 and 6 or *
+    job: if provided, assumes we are updated an existing entry.
     """
     cron = self.get_crontab()
 

--- a/watchme/watchers/settings.py
+++ b/watchme/watchers/settings.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.logger import bot
 
@@ -14,11 +8,11 @@ from watchme.logger import bot
 def remove_setting(self, section, name, save=True):
     """remove a setting from the configuration file
 
-       Parameters
-       ==========
-       section: the name of the section (task)
-       name: the name of the variable to remove
-       save: save the configuration file (default is True)
+    Parameters
+    ==========
+    section: the name of the section (task)
+    name: the name of the variable to remove
+    save: save the configuration file (default is True)
     """
     removed = False
     self.load_config()
@@ -38,10 +32,10 @@ def remove_setting(self, section, name, save=True):
 def remove_section(self, section, save=True):
     """remove a setting from the configuration file
 
-       Parameters
-       ==========
-       section: the name of the section (task)
-       save: save the configuration file (default is True)
+    Parameters
+    ==========
+    section: the name of the section (task)
+    save: save the configuration file (default is True)
     """
     removed = False
     self.load_config()
@@ -61,9 +55,9 @@ def remove_section(self, section, save=True):
 def print_add_task(self, task):
     """assemble a task section into a command that can create/add it.
 
-       Parameters
-       ==========
-       task: the name of the task to inspect
+    Parameters
+    ==========
+    task: the name of the task to inspect
     """
     self.load_config()
 
@@ -80,11 +74,11 @@ def print_add_task(self, task):
 
 def print_section(self, section):
     """print a section (usually a task) from a configuration file,
-       if it exists.
+    if it exists.
 
-       Parameters
-       ==========
-       section: the name of the section (task)
+    Parameters
+    ==========
+    section: the name of the section (task)
     """
     self.load_config()
 
@@ -99,13 +93,13 @@ def print_section(self, section):
 
 def get_setting(self, section, name, default=None):
     """return a setting from the config, if defined. Otherwise return
-       default (None or set by user)
-       
-       Parameters
-       ==========
-       section: the section in the config, defaults to self.name
-       name: they key (index) of the setting to look up
-       default: (optional) if not found, return default instead.
+    default (None or set by user)
+
+    Parameters
+    ==========
+    section: the section in the config, defaults to self.name
+    name: they key (index) of the setting to look up
+    default: (optional) if not found, return default instead.
     """
     self.load_config()
 
@@ -122,10 +116,10 @@ def get_setting(self, section, name, default=None):
 
 def has_setting(self, section, name):
     """return a boolean if a config has a setting (or not)
-       Parameters
-       ==========
-       section: the section in the config, defaults to self.name
-       name: they key (index) of the setting to look up
+    Parameters
+    ==========
+    section: the section in the config, defaults to self.name
+    name: they key (index) of the setting to look up
     """
     self.load_config()
 
@@ -139,9 +133,9 @@ def has_setting(self, section, name):
 
 def has_section(self, section):
     """return a boolean if a config has a section (e.g., a task or exporter)
-       Parameters
-       ==========
-       section: the section in the config
+    Parameters
+    ==========
+    section: the section in the config
     """
     self.load_config()
     return section in self.config
@@ -149,13 +143,13 @@ def has_section(self, section):
 
 def set_setting(self, section, key, value):
     """set a key value pair in a section, if the section exists. Returns
-       a boolean (True or False) to indicate if added.
+    a boolean (True or False) to indicate if added.
 
-       Parameters
-       ==========
-       section: the section in the config, defaults to self.name
-       key: they key (index) of the setting to set
-       value: the value to set.
+    Parameters
+    ==========
+    section: the section in the config, defaults to self.name
+    key: they key (index) of the setting to set
+    value: the value to set.
     """
     self.load_config()
 
@@ -168,8 +162,7 @@ def set_setting(self, section, key, value):
 
 
 def get_section(self, name):
-    """get a section from the config, if it exists
-    """
+    """get a section from the config, if it exists"""
     section = None
     self.load_config()
     if name in self.config:

--- a/watchme/watchers/urls/__init__.py
+++ b/watchme/watchers/urls/__init__.py
@@ -1,13 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.tasks import TaskBase
 from watchme.logger import bot
@@ -30,10 +23,10 @@ class Task(TaskBase):
         super(Task, self).__init__(name, params, **kwargs)
 
     def _validate(self):
-        """additional validation function, called by validate() of 
-           superclass. Here we assume all required self.params are included.
-           If an parameter is found to be invalid, self.valid should be set
-           to False
+        """additional validation function, called by validate() of
+        superclass. Here we assume all required self.params are included.
+        If an parameter is found to be invalid, self.valid should be set
+        to False
         """
         # The url must begin with http
         if not self.params["url"].startswith("http"):
@@ -42,11 +35,11 @@ class Task(TaskBase):
 
     def export_func(self):
         """this function should return the correct task (from the tasks.py
-           in the same folder) based on some logic of the params that are given
-           by the user (self.params). If there is only one kind of function for
-           the task, it's fairly easy to import and return it here. This
-           function should take no arguments, but instead use the self.params
-           already provided in the client.
+        in the same folder) based on some logic of the params that are given
+        by the user (self.params). If there is only one kind of function for
+        the task, it's fairly easy to import and return it here. This
+        function should take no arguments, but instead use the self.params
+        already provided in the client.
         """
         name = self.params.get("func", "get_task")
 

--- a/watchme/watchers/urls/helpers.py
+++ b/watchme/watchers/urls/helpers.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 import requests
 import re
@@ -15,14 +9,14 @@ import re
 
 
 def get_params(kwargs, key="url_param_"):
-    """a general function to get parameter sets based on a user input. 
-       Returns a list of dictionaries, one per set.
+    """a general function to get parameter sets based on a user input.
+    Returns a list of dictionaries, one per set.
 
-       Parameters
-       ==========
-       kwargs: the dictionary of keyword arguments that may contain url
-               parameters (format is url_param_<name>
-       key: the string that the parameters start with (defaults to url_param)
+    Parameters
+    ==========
+    kwargs: the dictionary of keyword arguments that may contain url
+            parameters (format is url_param_<name>
+    key: the string that the parameters start with (defaults to url_param)
     """
     # Keey dictionary based on index of param
     params = {}
@@ -58,14 +52,14 @@ def get_params(kwargs, key="url_param_"):
 
 def parse_success_response(response, kwargs):
     """parse a successful response of 200, meaning we honor the user
-       request to return json, search for a regular expression, or return
-       raw text. This is used by the basic GET/POST functions. For parsing
-       with beautiful soup, see "get_results" and "get_url_selection"
+    request to return json, search for a regular expression, or return
+    raw text. This is used by the basic GET/POST functions. For parsing
+    with beautiful soup, see "get_results" and "get_url_selection"
 
-       Parameters
-       ==========
-       response: the requests (200) response
-       kwargs: dictionary of keyword arguments provided to function
+    Parameters
+    ==========
+    response: the requests (200) response
+    kwargs: dictionary of keyword arguments provided to function
     """
     result = None
     save_as = kwargs.get("save_as", "json")
@@ -88,12 +82,12 @@ def parse_success_response(response, kwargs):
 
 def get_headers(kwargs):
     """Get a single set of headers from the kwargs dict. A user agent is added
-       as it is helpful in most cases.
+    as it is helpful in most cases.
 
-       Parameters
-       ==========
-       kwargs: the dictionary of keyword arguments that may contain url
-               parameters (format is url_param_<name>
+    Parameters
+    ==========
+    kwargs: the dictionary of keyword arguments that may contain url
+            parameters (format is url_param_<name>
     """
     headers = {"User-Agent": "Mozilla/5.0"}
 
@@ -123,19 +117,19 @@ def get_results(
     regex=None,
 ):
 
-    """given a url, a function, an optional selector, optional attributes, 
-       and a set (dict) of parameters, perform a request. This function is
-       used if the calling function needs special parsing of the html with
-       beautiful soup. If only a post/get is needed, this is not necessary.
+    """given a url, a function, an optional selector, optional attributes,
+    and a set (dict) of parameters, perform a request. This function is
+    used if the calling function needs special parsing of the html with
+    beautiful soup. If only a post/get is needed, this is not necessary.
 
-       Parameters
-       ==========
-       url: the url to get (required)
-       func: the function to use, defaults to requests.get
-       selector:  selection for the html response
-       attributes: optional, a list of attributes
-       params: a dictionary of parameters
-       headers: a dictionary of header key value pairs
+    Parameters
+    ==========
+    url: the url to get (required)
+    func: the function to use, defaults to requests.get
+    selector:  selection for the html response
+    attributes: optional, a list of attributes
+    params: a dictionary of parameters
+    headers: a dictionary of header key value pairs
     """
     from bs4 import BeautifulSoup
 

--- a/watchme/watchers/urls/tasks.py
+++ b/watchme/watchers/urls/tasks.py
@@ -1,12 +1,6 @@
-"""
-
-Copyright (C) 2019-2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 from watchme.logger import bot
 from .helpers import get_params, get_results, get_headers, parse_success_response
@@ -17,17 +11,17 @@ import requests
 
 def get_task(url, **kwargs):
     """a simple task to use requests to get a url. By default, we return
-       the raw response.
+    the raw response.
 
-       Parameters
-       ==========
+    Parameters
+    ==========
 
-       REQUIRED:
-           url: a url to return the page for
+    REQUIRED:
+        url: a url to return the page for
 
-       OPTIONAL
-           regex: a regular expression to search the text for (not used w/ json)
-           save_as: return the result to save as json
+    OPTIONAL
+        regex: a regular expression to search the text for (not used w/ json)
+        save_as: return the result to save as json
     """
     results = []
     paramsets = get_params(kwargs)
@@ -53,11 +47,11 @@ def get_task(url, **kwargs):
 def post_task(url, **kwargs):
     """a simple task to use requests to post to. By default, we return json.
 
-       Parameters
-       ==========
+    Parameters
+    ==========
 
-       REQUIRED:
-           url: a url to post to
+    REQUIRED:
+        url: a url to post to
     """
     results = []
 
@@ -90,17 +84,17 @@ def post_task(url, **kwargs):
 
 def download_task(url, **kwargs):
     """a simple task to use requests to get a url. By default, we return
-       the raw response.
+    the raw response.
 
-       Parameters
-       ==========
+    Parameters
+    ==========
 
-       REQUIRED:
-           url: a url to download (stream)
+    REQUIRED:
+        url: a url to download (stream)
 
-       OPTIONAL:
-           write_format: to change from default "w"
-           disable_ssl_check: set to anything to not verify (not recommended)
+    OPTIONAL:
+        write_format: to change from default "w"
+        disable_ssl_check: set to anything to not verify (not recommended)
     """
     result = None
 
@@ -148,9 +142,9 @@ def download_task(url, **kwargs):
 def get_url_selection(url, **kwargs):
     """select some content from a page dynamically, using selenium.
 
-       Parameters
-       ==========
-       kwargs: a dictionary of key, value pairs provided by the user
+    Parameters
+    ==========
+    kwargs: a dictionary of key, value pairs provided by the user
     """
 
     results = None


### PR DESCRIPTION
This PR will do the following:

 - update the typo in the docs that a GitHub releases url should retrieve text
 - update headers
 - run black for a recent version
 
This will close #69 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>